### PR TITLE
reduce memory footprint of json.Marshal for large values

### DIFF
--- a/json/encode.go
+++ b/json/encode.go
@@ -13,6 +13,8 @@ import (
 	"unsafe"
 )
 
+const hex = "0123456789abcdef"
+
 func (e encoder) encodeNull(b []byte, p unsafe.Pointer) ([]byte, error) {
 	return append(b, "null"...), nil
 }
@@ -124,8 +126,6 @@ func (e encoder) encodeNumber(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (e encoder) encodeString(b []byte, p unsafe.Pointer) ([]byte, error) {
-	hex := "0123456789abcdef"
-
 	s := *(*string)(p)
 	i := 0
 	j := 0
@@ -235,8 +235,7 @@ func (e encoder) encodeToString(b []byte, p unsafe.Pointer, encode encodeFunc) (
 	}
 
 	j := len(b)
-	x := b[i:]
-	s := *(*string)(unsafe.Pointer(&x))
+	s := b[i:]
 
 	if b, err = e.encodeString(b, unsafe.Pointer(&s)); err != nil {
 		return b, err
@@ -661,7 +660,6 @@ func (e encoder) encodeTextMarshaler(b []byte, p unsafe.Pointer, t reflect.Type,
 }
 
 func appendCompactEscapeHTML(dst []byte, src []byte) []byte {
-	const hex = "0123456789abcdef"
 	start := 0
 	escape := false
 	inString := false


### PR DESCRIPTION
Here's one more, basically I realized we had missed that optimization that @jnjackins had landed in `encoding/json`. It seems to yield some good results, especially when marshaling large values:
```
benchmark                      old ns/op     new ns/op     delta
BenchmarkCodeMarshal           6374672       5463152       -14.30%
BenchmarkMarshalBytes/32       264           147           -44.32%
BenchmarkMarshalBytes/256      470           419           -10.85%
BenchmarkMarshalBytes/4096     5451          4514          -17.19%

benchmark                old MB/s     new MB/s     speedup
BenchmarkCodeMarshal     304.40       355.19       1.17x

benchmark                      old allocs     new allocs     delta
BenchmarkCodeMarshal           31             1              -96.77%
BenchmarkMarshalBytes/32       1              1              +0.00%
BenchmarkMarshalBytes/256      1              1              +0.00%
BenchmarkMarshalBytes/4096     3              1              -66.67%

benchmark                      old bytes     new bytes     delta
BenchmarkCodeMarshal           11654144      1941530       -83.34%
BenchmarkMarshalBytes/32       1024          64            -93.75%
BenchmarkMarshalBytes/256      1024          384           -62.50%
BenchmarkMarshalBytes/4096     14080         6144          -56.36%
```