### PR TITLE
optimize struct field encoding

### DIFF
--- a/json/encode.go
+++ b/json/encode.go
@@ -526,6 +526,7 @@ func (e encoder) encodeMapStringRawMessage(b []byte, p unsafe.Pointer) ([]byte, 
 func (e encoder) encodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byte, error) {
 	var start = len(b)
 	var err error
+	var k string
 	var n int
 	b = append(b, '{')
 
@@ -541,13 +542,19 @@ func (e encoder) encodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 			b = append(b, ',')
 		}
 
-		k := len(b)
-		b, _ = e.encodeString(b, unsafe.Pointer(&f.name))
+		if (e.flags & EscapeHTML) != 0 {
+			k = f.html
+		} else {
+			k = f.json
+		}
+
+		lengthBeforeKey := len(b)
+		b = append(b, k...)
 		b = append(b, ':')
 
 		if b, err = f.codec.encode(e, b, v); err != nil {
 			if err == (rollback{}) {
-				b = b[:k]
+				b = b[:lengthBeforeKey]
 				continue
 			}
 			return b[:start], err


### PR DESCRIPTION
Yesterday someone pointed out https://github.com/golang/go/issues/32779 which made me realize we could reduce the CPU time spent encoding structs since the serialized form of the keys is known when we generate the encoders.

The change seems to yield good result, the more struct keys the better:
```
benchmark                                  old ns/op     new ns/op     delta
BenchmarkMarshal/struct_{}                 17.9          18.0          +0.56%
BenchmarkMarshal/struct_{_A_int_}          34.9          32.4          -7.16%
BenchmarkMarshal/struct_{_A_int;_B_int...  70.7          57.8          -18.25%
BenchmarkMarshal/struct_{_A_int;_T_tim...  287           283           -1.39%
BenchmarkMarshal/struct_{_X_*int_}         36.7          34.0          -7.36%
BenchmarkMarshal/struct_{_X_*int_}#01      45.4          42.7          -5.95%
BenchmarkMarshal/struct_{_X_**int_}        37.6          33.5          -10.90%
BenchmarkMarshal/struct_{_X_*int;_Y...     49.9          43.6          -12.63%
BenchmarkMarshal/struct_{_X_*int;_Y...#01  71.5          59.8          -16.36%
BenchmarkMarshal/struct_{_A_string_...     186           173           -6.99%
BenchmarkMarshal/struct_{_json.point_}     58.2          51.9          -10.82%
BenchmarkMarshal/*json.codeResponse2       4891069       4001282       -18.19%
BenchmarkCodeMarshal                       5507094       4519025       -17.94%
```
