### PR TITLE
Compare errors when fuzzing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ $(go-fuzz-build):
 	GO111MODULE=off go install github.com/dvyukov/go-fuzz/go-fuzz-build
 
 $(go-fuzz-corpus):
-	GO111MODULE=off go get github.com/dvyukov/go-fuzz/go-fuzz-corpus
+	GO111MODULE=off go get github.com/dvyukov/go-fuzz-corpus
 
 $(go-fuzz-dep):
 	GO111MODULE=off go get github.com/dvyukov/go-fuzz/go-fuzz-dep

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ go-fuzz-corpus := ${GOPATH}/src/github.com/dvyukov/go-fuzz-corpus
 go-fuzz-dep := ${GOPATH}/src/github.com/dvyukov/go-fuzz/go-fuzz-dep
 
 test:
+	go test -v -cover ./ascii
 	go test -v -cover ./json
 	go test -v -cover ./iso8601
 	go run ./json/bugs/issue11/main.go

--- a/ascii/valid.go
+++ b/ascii/valid.go
@@ -1,6 +1,8 @@
 package ascii
 
-import "unsafe"
+import (
+	"unsafe"
+)
 
 // Valid returns true if b contains only ASCII characters.
 func Valid(b []byte) bool {
@@ -10,6 +12,16 @@ func Valid(b []byte) bool {
 // ValidString returns true if s contains only ASCII characters.
 func ValidString(s string) bool {
 	return valid(unsafe.Pointer(&s), uintptr(len(s)))
+}
+
+// ValidBytes returns true if b is an ASCII character.
+func ValidByte(b byte) bool {
+	return b <= 0x7f
+}
+
+// ValidBytes returns true if b is an ASCII character.
+func ValidRune(r rune) bool {
+	return r <= 0x7f
 }
 
 //go:nosplit
@@ -42,11 +54,98 @@ func valid(s unsafe.Pointer, n uintptr) bool {
 		i += 2
 	}
 
-	if (n - i) >= 1 {
+	if i < n {
 		if ((*(*uint8)(unsafe.Pointer(uintptr(p) + i))) & 0x80) != 0 {
 			return false
 		}
 	}
 
 	return true
+}
+
+// Valid returns true if b contains only printable ASCII characters.
+func ValidPrint(b []byte) bool {
+	return validPrint(unsafe.Pointer(&b), uintptr(len(b)))
+}
+
+// ValidString returns true if s contains only printable ASCII characters.
+func ValidPrintString(s string) bool {
+	return validPrint(unsafe.Pointer(&s), uintptr(len(s)))
+}
+
+// ValidBytes returns true if b is an ASCII character.
+func ValidPrintByte(b byte) bool {
+	return 0x20 <= b && b <= 0x7f
+}
+
+// ValidBytes returns true if b is an ASCII character.
+func ValidPrintRune(r rune) bool {
+	return 0x20 <= r && r <= 0x7f
+}
+
+//go:nosplit
+func validPrint(s unsafe.Pointer, n uintptr) bool {
+	if n == 0 {
+		return true
+	}
+
+	i := uintptr(0)
+	p := *(*unsafe.Pointer)(s)
+
+	for (n - i) >= 8 {
+		x := *(*uint64)(unsafe.Pointer(uintptr(p) + i))
+		if ((x & 0x8080808080808080) != 0) || hasLess64(x, 0x20) {
+			return false
+		}
+		i += 8
+	}
+
+	if (n - i) >= 4 {
+		x := *(*uint32)(unsafe.Pointer(uintptr(p) + i))
+		if ((x & 0x80808080) != 0) || hasLess32(x, 0x20) {
+			return false
+		}
+		i += 4
+	}
+
+	if (n - i) >= 2 {
+		x := *(*uint16)(unsafe.Pointer(uintptr(p) + i))
+		if ((x & 0x8080) != 0) || hasLess16(x, 0x20) {
+			return false
+		}
+		i += 2
+	}
+
+	if i < n {
+		x := *(*uint8)(unsafe.Pointer(uintptr(p) + i))
+		if ((x & 0x80) != 0) || x < 0x20 {
+			return false
+		}
+	}
+
+	return true
+}
+
+// https://graphics.stanford.edu/~seander/bithacks.html#HasLessInWord
+const (
+	hasLessConstL64 = (^uint64(0)) / 255
+	hasLessConstR64 = hasLessConstL64 * 128
+
+	hasLessConstL32 = (^uint32(0)) / 255
+	hasLessConstR32 = hasLessConstL32 * 128
+)
+
+//go:nosplit
+func hasLess64(x, n uint64) bool {
+	return ((x - (hasLessConstL64 * n)) & ^x & hasLessConstR64) != 0
+}
+
+//go:nosplit
+func hasLess32(x, n uint32) bool {
+	return ((x - (hasLessConstL32 * n)) & ^x & hasLessConstR32) != 0
+}
+
+//go:nosplit
+func hasLess16(x, n uint16) bool {
+	return ((x >> 8) < n) || ((x & 0xff) < n)
 }

--- a/json/codec.go
+++ b/json/codec.go
@@ -972,11 +972,12 @@ var (
 	int32Type = reflect.TypeOf(int32(0))
 	int64Type = reflect.TypeOf(int64(0))
 
-	uintType   = reflect.TypeOf(uint(0))
-	uint8Type  = reflect.TypeOf(uint8(0))
-	uint16Type = reflect.TypeOf(uint16(0))
-	uint32Type = reflect.TypeOf(uint32(0))
-	uint64Type = reflect.TypeOf(uint64(0))
+	uintType    = reflect.TypeOf(uint(0))
+	uint8Type   = reflect.TypeOf(uint8(0))
+	uint16Type  = reflect.TypeOf(uint16(0))
+	uint32Type  = reflect.TypeOf(uint32(0))
+	uint64Type  = reflect.TypeOf(uint64(0))
+	uintptrType = reflect.TypeOf(uintptr(0))
 
 	float32Type = reflect.TypeOf(float32(0))
 	float64Type = reflect.TypeOf(float64(0))

--- a/json/codec.go
+++ b/json/codec.go
@@ -221,6 +221,12 @@ func constructStringDecodeFunc(decode decodeFunc) decodeFunc {
 	}
 }
 
+func constructStringToIntDecodeFunc(decode decodeFunc) decodeFunc {
+	return func(d decoder, b []byte, p unsafe.Pointer) ([]byte, error) {
+		return d.decodeStringToInt(b, p, decode)
+	}
+}
+
 func constructArrayCodec(t reflect.Type, seen map[reflect.Type]*structType) codec {
 	e := t.Elem()
 	c := constructCodec(e, seen)
@@ -602,7 +608,7 @@ func appendStructFields(fields []structField, t reflect.Type, offset uintptr, se
 				reflect.Float64,
 				reflect.String:
 				codec.encode = constructStringEncodeFunc(codec.encode)
-				codec.decode = constructStringDecodeFunc(codec.decode)
+				codec.decode = constructStringToIntDecodeFunc(codec.decode)
 			}
 		}
 

--- a/json/codec.go
+++ b/json/codec.go
@@ -592,8 +592,7 @@ func appendStructFields(fields []structField, t reflect.Type, offset uintptr, se
 			}
 
 			switch typ.Kind() {
-			case reflect.Bool,
-				reflect.Int,
+			case reflect.Int,
 				reflect.Int8,
 				reflect.Int16,
 				reflect.Int32,
@@ -603,12 +602,15 @@ func appendStructFields(fields []structField, t reflect.Type, offset uintptr, se
 				reflect.Uint8,
 				reflect.Uint16,
 				reflect.Uint32,
-				reflect.Uint64,
+				reflect.Uint64:
+				codec.encode = constructStringEncodeFunc(codec.encode)
+				codec.decode = constructStringToIntDecodeFunc(typ, codec.decode)
+			case reflect.Bool,
 				reflect.Float32,
 				reflect.Float64,
 				reflect.String:
 				codec.encode = constructStringEncodeFunc(codec.encode)
-				codec.decode = constructStringToIntDecodeFunc(typ, codec.decode)
+				codec.decode = constructStringDecodeFunc(codec.decode)
 			}
 		}
 

--- a/json/codec.go
+++ b/json/codec.go
@@ -221,9 +221,9 @@ func constructStringDecodeFunc(decode decodeFunc) decodeFunc {
 	}
 }
 
-func constructStringToIntDecodeFunc(decode decodeFunc) decodeFunc {
+func constructStringToIntDecodeFunc(t reflect.Type, decode decodeFunc) decodeFunc {
 	return func(d decoder, b []byte, p unsafe.Pointer) ([]byte, error) {
-		return d.decodeStringToInt(b, p, decode)
+		return d.decodeFromStringToInt(b, p, t, decode)
 	}
 }
 
@@ -608,7 +608,7 @@ func appendStructFields(fields []structField, t reflect.Type, offset uintptr, se
 				reflect.Float64,
 				reflect.String:
 				codec.encode = constructStringEncodeFunc(codec.encode)
-				codec.decode = constructStringToIntDecodeFunc(codec.decode)
+				codec.decode = constructStringToIntDecodeFunc(typ, codec.decode)
 			}
 		}
 

--- a/json/decode.go
+++ b/json/decode.go
@@ -377,8 +377,14 @@ func (d decoder) decodeFromStringToInt(b []byte, p unsafe.Pointer, t reflect.Typ
 		if _, isSyntaxError := err.(*SyntaxError); isSyntaxError {
 			return b, fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal %q into int", v)
 		}
-		if _, _, err := parseValue(v); err == nil {
-			return b, fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal %q into int", v)
+		// When the input value was a valid number representation we retain the
+		// error returned by the decoder.
+		if _, _, err := parseNumber(v); err != nil {
+			// When the input value valid JSON we mirror the behavior of the
+			// encoding/json package and return a generic error.
+			if _, _, err := parseValue(v); err == nil {
+				return b, fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal %q into int", v)
+			}
 		}
 		return b, err
 	} else if len(r) != 0 {

--- a/json/decode.go
+++ b/json/decode.go
@@ -17,7 +17,7 @@ func (d decoder) decodeNull(b []byte, p unsafe.Pointer) ([]byte, error) {
 	if hasPrefix(b, "null") {
 		return b[4:], nil
 	}
-	return b, unmarshalTypeError(b, nullType)
+	return inputError(b, nullType)
 }
 
 func (d decoder) decodeBool(b []byte, p unsafe.Pointer) ([]byte, error) {
@@ -34,7 +34,7 @@ func (d decoder) decodeBool(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 
 	default:
-		return b, unmarshalTypeError(b, boolType)
+		return inputError(b, boolType)
 	}
 }
 
@@ -45,7 +45,7 @@ func (d decoder) decodeInt(b []byte, p unsafe.Pointer) ([]byte, error) {
 
 	v, r, err := parseInt(b)
 	if err != nil {
-		return r, unmarshalTypeError(b, intType)
+		return inputError(b, intType)
 	}
 
 	*(*int)(p) = int(v)
@@ -59,7 +59,7 @@ func (d decoder) decodeInt8(b []byte, p unsafe.Pointer) ([]byte, error) {
 
 	v, r, err := parseInt(b)
 	if err != nil {
-		return r, unmarshalTypeError(b, int8Type)
+		return inputError(b, int8Type)
 	}
 
 	if v < math.MinInt8 || v > math.MaxInt8 {
@@ -77,7 +77,7 @@ func (d decoder) decodeInt16(b []byte, p unsafe.Pointer) ([]byte, error) {
 
 	v, r, err := parseInt(b)
 	if err != nil {
-		return r, unmarshalTypeError(b, int16Type)
+		return inputError(b, int16Type)
 	}
 
 	if v < math.MinInt16 || v > math.MaxInt16 {
@@ -95,7 +95,7 @@ func (d decoder) decodeInt32(b []byte, p unsafe.Pointer) ([]byte, error) {
 
 	v, r, err := parseInt(b)
 	if err != nil {
-		return r, unmarshalTypeError(b, int32Type)
+		return inputError(b, int32Type)
 	}
 
 	if v < math.MinInt32 || v > math.MaxInt32 {
@@ -113,7 +113,7 @@ func (d decoder) decodeInt64(b []byte, p unsafe.Pointer) ([]byte, error) {
 
 	v, r, err := parseInt(b)
 	if err != nil {
-		return r, unmarshalTypeError(b, int64Type)
+		return inputError(b, int64Type)
 	}
 
 	*(*int64)(p) = v
@@ -127,7 +127,7 @@ func (d decoder) decodeUint(b []byte, p unsafe.Pointer) ([]byte, error) {
 
 	v, r, err := parseUint(b)
 	if err != nil {
-		return r, unmarshalTypeError(b, uintType)
+		return inputError(b, uintType)
 	}
 
 	*(*uint)(p) = uint(v)
@@ -141,7 +141,7 @@ func (d decoder) decodeUintptr(b []byte, p unsafe.Pointer) ([]byte, error) {
 
 	v, r, err := parseUint(b)
 	if err != nil {
-		return r, unmarshalTypeError(b, uintType)
+		return inputError(b, uintType)
 	}
 
 	*(*uintptr)(p) = uintptr(v)
@@ -155,7 +155,7 @@ func (d decoder) decodeUint8(b []byte, p unsafe.Pointer) ([]byte, error) {
 
 	v, r, err := parseUint(b)
 	if err != nil {
-		return r, unmarshalTypeError(b, uint8Type)
+		return inputError(b, uint8Type)
 	}
 
 	if v > math.MaxUint8 {
@@ -173,7 +173,7 @@ func (d decoder) decodeUint16(b []byte, p unsafe.Pointer) ([]byte, error) {
 
 	v, r, err := parseUint(b)
 	if err != nil {
-		return r, unmarshalTypeError(b, uint16Type)
+		return inputError(b, uint16Type)
 	}
 
 	if v > math.MaxUint16 {
@@ -191,7 +191,7 @@ func (d decoder) decodeUint32(b []byte, p unsafe.Pointer) ([]byte, error) {
 
 	v, r, err := parseUint(b)
 	if err != nil {
-		return r, unmarshalTypeError(b, uint32Type)
+		return inputError(b, uint32Type)
 	}
 
 	if v > math.MaxUint32 {
@@ -209,7 +209,7 @@ func (d decoder) decodeUint64(b []byte, p unsafe.Pointer) ([]byte, error) {
 
 	v, r, err := parseUint(b)
 	if err != nil {
-		return r, unmarshalTypeError(b, uint64Type)
+		return inputError(b, uint64Type)
 	}
 
 	*(*uint64)(p) = v
@@ -223,12 +223,12 @@ func (d decoder) decodeFloat32(b []byte, p unsafe.Pointer) ([]byte, error) {
 
 	v, r, err := parseNumber(b)
 	if err != nil {
-		return r, unmarshalTypeError(b, float32Type)
+		return inputError(b, float32Type)
 	}
 
 	f, err := strconv.ParseFloat(*(*string)(unsafe.Pointer(&v)), 32)
 	if err != nil {
-		return r, unmarshalTypeError(b, float32Type)
+		return inputError(b, float32Type)
 	}
 
 	*(*float32)(p) = float32(f)
@@ -242,12 +242,12 @@ func (d decoder) decodeFloat64(b []byte, p unsafe.Pointer) ([]byte, error) {
 
 	v, r, err := parseNumber(b)
 	if err != nil {
-		return r, unmarshalTypeError(b, float64Type)
+		return inputError(b, float64Type)
 	}
 
 	f, err := strconv.ParseFloat(*(*string)(unsafe.Pointer(&v)), 64)
 	if err != nil {
-		return r, unmarshalTypeError(b, float64Type)
+		return inputError(b, float64Type)
 	}
 
 	*(*float64)(p) = f
@@ -261,7 +261,7 @@ func (d decoder) decodeNumber(b []byte, p unsafe.Pointer) ([]byte, error) {
 
 	v, r, err := parseNumber(b)
 	if err != nil {
-		return r, unmarshalTypeError(b, numberType)
+		return inputError(b, numberType)
 	}
 
 	if (d.flags & DontCopyNumber) != 0 {
@@ -280,7 +280,7 @@ func (d decoder) decodeString(b []byte, p unsafe.Pointer) ([]byte, error) {
 
 	s, r, new, err := parseStringUnquote(b, nil)
 	if err != nil {
-		return b, unmarshalTypeError(r, stringType)
+		return inputError(b, stringType)
 	}
 
 	if new || (d.flags&DontCopyString) != 0 {
@@ -299,7 +299,7 @@ func (d decoder) decodeFromString(b []byte, p unsafe.Pointer, decode decodeFunc)
 
 	v, b, _, err := parseStringUnquote(b, nil)
 	if err != nil {
-		return b, unmarshalTypeError(v, stringType)
+		return inputError(v, stringType)
 	}
 
 	if v, err = decode(d, v, p); err != nil {
@@ -323,21 +323,21 @@ func (d decoder) decodeBytes(b []byte, p unsafe.Pointer) ([]byte, error) {
 		if len(b) >= 1 && b[0] == '[' {
 			return d.decodeSlice(b, p, 1, bytesType, decoder.decodeUint8)
 		}
-		return b, unmarshalTypeError(b, bytesType)
+		return inputError(b, bytesType)
 	}
 
 	// The input string contains escaped sequences, we need to parse it before
 	// decoding it to match the encoding/json package behvaior.
 	src, r, _, err := parseStringUnquote(b, nil)
 	if err != nil {
-		return b, unmarshalTypeError(b, bytesType)
+		return inputError(b, bytesType)
 	}
 
 	dst := make([]byte, base64.StdEncoding.DecodedLen(len(src)))
 
 	n, err := base64.StdEncoding.Decode(dst, src)
 	if err != nil {
-		return b, unmarshalTypeError(b, bytesType)
+		return inputError(b, bytesType)
 	}
 
 	*(*[]byte)(p) = dst[:n]
@@ -356,7 +356,7 @@ func (d decoder) decodeDuration(b []byte, p unsafe.Pointer) ([]byte, error) {
 	if len(b) > 0 && b[0] != '"' {
 		v, r, err := parseInt(b)
 		if err != nil {
-			return r, unmarshalTypeError(b, int32Type)
+			return inputError(b, int32Type)
 		}
 
 		if v < math.MinInt64 || v > math.MaxInt64 {
@@ -368,19 +368,19 @@ func (d decoder) decodeDuration(b []byte, p unsafe.Pointer) ([]byte, error) {
 	}
 
 	if len(b) < 2 || b[0] != '"' {
-		return b, unmarshalTypeError(b, durationType)
+		return inputError(b, durationType)
 	}
 
 	i := bytes.IndexByte(b[1:], '"') + 1
 	if i <= 0 {
-		return b, unmarshalTypeError(b, durationType)
+		return inputError(b, durationType)
 	}
 
 	s := b[1:i] // trim quotes
 
 	v, err := time.ParseDuration(*(*string)(unsafe.Pointer(&s)))
 	if err != nil {
-		return b, unmarshalTypeError(b, durationType)
+		return inputError(b, durationType)
 	}
 
 	*(*time.Duration)(p) = v
@@ -393,19 +393,19 @@ func (d decoder) decodeTime(b []byte, p unsafe.Pointer) ([]byte, error) {
 	}
 
 	if len(b) < 2 || b[0] != '"' {
-		return b, unmarshalTypeError(b, durationType)
+		return inputError(b, timeType)
 	}
 
 	i := bytes.IndexByte(b[1:], '"') + 1
 	if i <= 0 {
-		return b, unmarshalTypeError(b, durationType)
+		return inputError(b, timeType)
 	}
 
 	s := b[1:i] // trim quotes
 
 	v, err := time.Parse(time.RFC3339Nano, *(*string)(unsafe.Pointer(&s)))
 	if err != nil {
-		return b, unmarshalTypeError(b, durationType)
+		return inputError(b, timeType)
 	}
 
 	*(*time.Time)(p) = v
@@ -418,7 +418,7 @@ func (d decoder) decodeArray(b []byte, p unsafe.Pointer, n int, size uintptr, t 
 	}
 
 	if len(b) < 2 || b[0] != '[' {
-		return b, unmarshalTypeError(b, t)
+		return inputError(b, t)
 	}
 	b = b[1:]
 
@@ -486,7 +486,7 @@ func (d decoder) decodeSlice(b []byte, p unsafe.Pointer, size uintptr, t reflect
 		if t.Elem().Kind() == reflect.Uint8 {
 			return d.decodeBytes(b, p)
 		}
-		return b, unmarshalTypeError(b, t)
+		return inputError(b, t)
 	}
 	b = b[1:]
 
@@ -549,7 +549,7 @@ func (d decoder) decodeMap(b []byte, p unsafe.Pointer, t, kt, vt reflect.Type, k
 	}
 
 	if len(b) < 2 || b[0] != '{' {
-		return b, unmarshalTypeError(b, t)
+		return inputError(b, t)
 	}
 	b = b[1:]
 
@@ -579,7 +579,7 @@ func (d decoder) decodeMap(b []byte, p unsafe.Pointer, t, kt, vt reflect.Type, k
 
 		if i != 0 {
 			if len(b) == 0 {
-				return b, syntaxError(b, "unexpected EOF after object field value")
+				return b, syntaxError(b, "unexpected end of JONS input after object field value")
 			}
 			if b[0] != ',' {
 				return b, syntaxError(b, "expected ',' after object field value but found '%c'", b[0])
@@ -588,12 +588,12 @@ func (d decoder) decodeMap(b []byte, p unsafe.Pointer, t, kt, vt reflect.Type, k
 		}
 
 		if b, err = decodeKey(d, b, kptr); err != nil {
-			return b, err
+			return objectKeyError(b, err)
 		}
 		b = skipSpaces(b)
 
 		if len(b) == 0 {
-			return b, syntaxError(b, "unexpected EOF after object field key")
+			return b, syntaxError(b, "unexpected end of JSON input after object field key")
 		}
 		if b[0] != ':' {
 			return b, syntaxError(b, "expected ':' after object field key but found '%c'", b[0])
@@ -620,7 +620,7 @@ func (d decoder) decodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, e
 	}
 
 	if len(b) < 2 || b[0] != '{' {
-		return b, unmarshalTypeError(b, mapStringInterfaceType)
+		return inputError(b, mapStringInterfaceType)
 	}
 	b = b[1:]
 
@@ -648,7 +648,7 @@ func (d decoder) decodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, e
 
 		if i != 0 {
 			if len(b) == 0 {
-				return b, syntaxError(b, "unexpected EOF after object field value")
+				return b, syntaxError(b, "unexpected end of JSON input after object field value")
 			}
 			if b[0] != ',' {
 				return b, syntaxError(b, "expected ',' after object field value but found '%c'", b[0])
@@ -658,12 +658,12 @@ func (d decoder) decodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, e
 
 		b, err = d.decodeString(b, unsafe.Pointer(&key))
 		if err != nil {
-			return b, err
+			return objectKeyError(b, err)
 		}
 		b = skipSpaces(b)
 
 		if len(b) == 0 {
-			return b, syntaxError(b, "unexpected EOF after object field key")
+			return b, syntaxError(b, "unexpected end of JSON input after object field key")
 		}
 		if b[0] != ':' {
 			return b, syntaxError(b, "expected ':' after object field key but found '%c'", b[0])
@@ -691,7 +691,7 @@ func (d decoder) decodeMapStringRawMessage(b []byte, p unsafe.Pointer) ([]byte, 
 	}
 
 	if len(b) < 2 || b[0] != '{' {
-		return b, unmarshalTypeError(b, mapStringInterfaceType)
+		return inputError(b, mapStringRawMessageType)
 	}
 	b = b[1:]
 
@@ -719,7 +719,7 @@ func (d decoder) decodeMapStringRawMessage(b []byte, p unsafe.Pointer) ([]byte, 
 
 		if i != 0 {
 			if len(b) == 0 {
-				return b, syntaxError(b, "unexpected EOF after object field value")
+				return b, syntaxError(b, "unexpected end of JSON input after object field value")
 			}
 			if b[0] != ',' {
 				return b, syntaxError(b, "expected ',' after object field value but found '%c'", b[0])
@@ -729,12 +729,12 @@ func (d decoder) decodeMapStringRawMessage(b []byte, p unsafe.Pointer) ([]byte, 
 
 		b, err = d.decodeString(b, unsafe.Pointer(&key))
 		if err != nil {
-			return b, err
+			return objectKeyError(b, err)
 		}
 		b = skipSpaces(b)
 
 		if len(b) == 0 {
-			return b, syntaxError(b, "unexpected EOF after object field key")
+			return b, syntaxError(b, "unexpected end of JSON input after object field key")
 		}
 		if b[0] != ':' {
 			return b, syntaxError(b, "expected ':' after object field key but found '%c'", b[0])
@@ -760,9 +760,8 @@ func (d decoder) decodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 		return b[4:], nil
 	}
 	if len(b) < 2 || b[0] != '{' {
-		return b, unmarshalTypeError(b, st.typ)
+		return inputError(b, st.typ)
 	}
-	b = b[1:]
 
 	var err error
 	var k []byte
@@ -771,7 +770,9 @@ func (d decoder) decodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 	// memory buffer used to convert short field names to lowercase
 	var buf [64]byte
 	var key []byte
+	var val = b
 
+	b = b[1:]
 	for {
 		b = skipSpaces(b)
 
@@ -781,7 +782,7 @@ func (d decoder) decodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 
 		if i != 0 {
 			if len(b) == 0 {
-				return b, syntaxError(b, "unexpected EOF after object field value")
+				return b, syntaxError(b, "unexpected end of JSON input after object field value")
 			}
 			if b[0] != ',' {
 				return b, syntaxError(b, "expected ',' after object field value but found '%c'", b[0])
@@ -792,12 +793,12 @@ func (d decoder) decodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 
 		k, b, _, err = parseStringUnquote(b, nil)
 		if err != nil {
-			return b, syntaxError(b, "parsing object field key: %s", err)
+			return objectKeyError(b, err)
 		}
 		b = skipSpaces(b)
 
 		if len(b) == 0 {
-			return b, syntaxError(b, "unexpected EOF after object field key")
+			return b, syntaxError(b, "unexpected end of JSON input after object field key")
 		}
 		if b[0] != ':' {
 			return b, syntaxError(b, "expected ':' after object field key but found '%c'", b[0])
@@ -822,6 +823,13 @@ func (d decoder) decodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 		}
 
 		if b, err = f.codec.decode(d, b, unsafe.Pointer(uintptr(p)+f.offset)); err != nil {
+			if b == nil {
+				_, r, perr := parseValue(val)
+				if perr != nil {
+					return r, perr
+				}
+				b = r
+			}
 			if e, ok := err.(*UnmarshalTypeError); ok {
 				e.Struct = st.typ.String() + e.Struct
 				e.Field = string(k) + "." + e.Field
@@ -836,7 +844,7 @@ func (d decoder) decodeEmbeddedStructPointer(b []byte, p unsafe.Pointer, t refle
 
 	if v == nil {
 		if unexported {
-			return b, fmt.Errorf("json: cannot set embedded pointer to unexported struct: %s", t)
+			return nil, fmt.Errorf("json: cannot set embedded pointer to unexported struct: %s", t)
 		}
 		v = unsafe.Pointer(reflect.New(t).Pointer())
 		*(*unsafe.Pointer)(p) = v
@@ -957,7 +965,7 @@ func (d decoder) decodeUnmarshalTypeError(b []byte, p unsafe.Pointer, t reflect.
 func (d decoder) decodeRawMessage(b []byte, p unsafe.Pointer) ([]byte, error) {
 	v, r, err := parseValue(b)
 	if err != nil {
-		return r, unmarshalTypeError(b, rawMessageType)
+		return inputError(b, rawMessageType)
 	}
 
 	if (d.flags & DontCopyRawMessage) == 0 {
@@ -992,12 +1000,20 @@ func (d decoder) decodeJSONUnmarshaler(b []byte, p unsafe.Pointer, t reflect.Typ
 func (d decoder) decodeTextUnmarshaler(b []byte, p unsafe.Pointer, t reflect.Type, pointer bool) ([]byte, error) {
 	var value string
 
-	switch b[0] {
+	v, b, err := parseValue(b)
+	if err != nil {
+		return b, err
+	}
+	if len(v) == 0 {
+		return inputError(v, t)
+	}
+
+	switch v[0] {
 	case 'n':
-		_, b, err := parseNull(b)
+		_, _, err := parseNull(v)
 		return b, err
 	case '"':
-		s, b, _, err := parseStringUnquote(b, nil)
+		s, _, _, err := parseStringUnquote(v, nil)
 		if err != nil {
 			return b, err
 		}

--- a/json/decode.go
+++ b/json/decode.go
@@ -377,6 +377,9 @@ func (d decoder) decodeFromStringToInt(b []byte, p unsafe.Pointer, t reflect.Typ
 		if _, isSyntaxError := err.(*SyntaxError); isSyntaxError {
 			return b, fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal %q into int", v)
 		}
+		if _, _, err := parseValue(v); err == nil {
+			return b, fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal %q into int", v)
+		}
 		return b, err
 	} else if len(r) != 0 {
 		return r, unmarshalTypeError(v, t)
@@ -387,6 +390,7 @@ func (d decoder) decodeFromStringToInt(b []byte, p unsafe.Pointer, t reflect.Typ
 
 func (d decoder) decodeBytes(b []byte, p unsafe.Pointer) ([]byte, error) {
 	if hasPrefix(b, "null") {
+		*(*[]byte)(p) = nil
 		return b[4:], nil
 	}
 

--- a/json/decode.go
+++ b/json/decode.go
@@ -780,7 +780,7 @@ func (d decoder) decodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 	// memory buffer used to convert short field names to lowercase
 	var buf [64]byte
 	var key []byte
-	var val = b
+	var input = b
 
 	b = b[1:]
 	for {
@@ -833,12 +833,12 @@ func (d decoder) decodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 		}
 
 		if b, err = f.codec.decode(d, b, unsafe.Pointer(uintptr(p)+f.offset)); err != nil {
-			if b == nil {
-				_, r, perr := parseValue(val)
-				if perr != nil {
-					return r, perr
+			if b == nil { // sentinel value returned by decodeEmbeddedStructPointer
+				if _, r, err := parseValue(input); err != nil {
+					return r, err
+				} else {
+					b = r
 				}
-				b = r
 			}
 			if e, ok := err.(*UnmarshalTypeError); ok {
 				e.Struct = st.typ.String() + e.Struct

--- a/json/decode.go
+++ b/json/decode.go
@@ -354,7 +354,7 @@ func (d decoder) decodeFromStringToInt(b []byte, p unsafe.Pointer, t reflect.Typ
 		return inputError(v, t)
 	}
 
-	if t.Kind() != reflect.Bool && len(v) > 0 && (v[0] == '-' || v[0] == '+' || v[0] == '0') {
+	if len(v) > 0 && (v[0] == '-' || v[0] == '+' || v[0] == '0') {
 		// In this context the encoding/json package accepts leading zeroes because
 		// it is not constrained by the JSON syntax, remove them so the parsing
 		// functions don't return syntax errors.

--- a/json/decode.go
+++ b/json/decode.go
@@ -354,7 +354,7 @@ func (d decoder) decodeFromStringToInt(b []byte, p unsafe.Pointer, t reflect.Typ
 		return inputError(v, t)
 	}
 
-	if t.Kind() != reflect.Bool && len(v) > 0 && v[0] == '-' || v[0] == '+' || v[0] == '0' {
+	if t.Kind() != reflect.Bool && len(v) > 0 && (v[0] == '-' || v[0] == '+' || v[0] == '0') {
 		// In this context the encoding/json package accepts leading zeroes because
 		// it is not constrained by the JSON syntax, remove them so the parsing
 		// functions don't return syntax errors.
@@ -366,7 +366,7 @@ func (d decoder) decodeFromStringToInt(b []byte, p unsafe.Pointer, t reflect.Typ
 			i++
 		}
 
-		for (i+1) < len(v) && v[i] == '0' && v[i+1] == '0' {
+		for (i+1) < len(v) && v[i] == '0' && '0' <= v[i+1] && v[i+1] <= '9' {
 			i++
 		}
 

--- a/json/decode.go
+++ b/json/decode.go
@@ -373,7 +373,7 @@ func (d decoder) decodeBytes(b []byte, p unsafe.Pointer) ([]byte, error) {
 
 	n, err := base64.StdEncoding.Decode(dst, src)
 	if err != nil {
-		return inputError(b, bytesType)
+		return r, err
 	}
 
 	*(*[]byte)(p) = dst[:n]
@@ -855,15 +855,16 @@ func (d decoder) decodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 		}
 		i++
 
+		if hasPrefix(b, "null") {
+			return b, syntaxError(b, "cannot decode object key string from 'null' value")
+		}
+
 		k, b, _, err = parseStringUnquote(b, nil)
 		if err != nil {
 			return objectKeyError(b, err)
 		}
 		b = skipSpaces(b)
 
-		if string(k) == "null" {
-			return b, syntaxError(b, "cannot decode object key string from 'null' value")
-		}
 		if len(b) == 0 {
 			return b, syntaxError(b, "unexpected end of JSON input after object field key")
 		}

--- a/json/decode.go
+++ b/json/decode.go
@@ -354,7 +354,7 @@ func (d decoder) decodeFromStringToInt(b []byte, p unsafe.Pointer, t reflect.Typ
 		return inputError(v, t)
 	}
 
-	if len(v) > 0 && (v[0] == '-' || v[0] == '+' || v[0] == '0') {
+	if hasLeadingZeroes(v) {
 		// In this context the encoding/json package accepts leading zeroes because
 		// it is not constrained by the JSON syntax, remove them so the parsing
 		// functions don't return syntax errors.

--- a/json/decode.go
+++ b/json/decode.go
@@ -373,11 +373,13 @@ func (d decoder) decodeFromStringToInt(b []byte, p unsafe.Pointer, t reflect.Typ
 		v = append(u, v[i:]...)
 	}
 
-	if _, err := decode(d, v, p); err != nil {
+	if r, err := decode(d, v, p); err != nil {
 		if _, isSyntaxError := err.(*SyntaxError); isSyntaxError {
 			return b, fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal %q into int", v)
 		}
 		return b, err
+	} else if len(r) != 0 {
+		return r, unmarshalTypeError(v, t)
 	}
 
 	return b, nil

--- a/json/encode.go
+++ b/json/encode.go
@@ -129,10 +129,9 @@ func (e encoder) encodeString(b []byte, p unsafe.Pointer) ([]byte, error) {
 	s := *(*string)(p)
 	i := 0
 	j := 0
+	escapeHTML := (e.flags & EscapeHTML) != 0
 
 	b = append(b, '"')
-
-	escapeHTML := (e.flags & EscapeHTML) != 0
 
 	for j < len(s) {
 		c := s[j]

--- a/json/fuzz/fuzz.go
+++ b/json/fuzz/fuzz.go
@@ -33,12 +33,24 @@ func Fuzz(data []byte) int {
 		// standard encoding/json package, whether it's right or wrong.
 		v1 := ctor()
 		v2 := ctor()
-		if encodingJSON.Unmarshal(data, v1) != nil {
-			continue
+		encodingErr := encodingJSON.Unmarshal(data, v1)
+		err := json.Unmarshal(data, v2)
+
+		if encodingErr != nil {
+			if err != nil {
+				// both implementations report an error
+				continue
+			} else {
+				panic(fmt.Errorf("encoding/json reported error but segmentio/json did not: %w", encodingErr))
+			}
+		} else {
+			if err != nil {
+				panic(fmt.Errorf("encoding/json did not report an error but segmentio/json did: %w", err))
+			} else {
+				// both implementations pass
+			}
 		}
-		if err := json.Unmarshal(data, v2); err != nil {
-			panic(err)
-		}
+
 		score = 1
 		fixS(v1)
 		fixS(v2)

--- a/json/fuzz/fuzz.go
+++ b/json/fuzz/fuzz.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	encodingJSON "encoding/json"
 	"fmt"
+	"reflect"
 
 	"github.com/dvyukov/go-fuzz-corpus/fuzz"
 	"github.com/segmentio/encoding/json"
@@ -39,13 +40,16 @@ func Fuzz(data []byte) int {
 		if encodingErr != nil {
 			if err != nil {
 				// both implementations report an error
+				if reflect.TypeOf(encodingErr) != reflect.TypeOf(err) {
+					panic(fmt.Errorf("error types mismatch: encoding/json=%T segmentio/encoding=%T", encodingErr, err))
+				}
 				continue
 			} else {
-				panic(fmt.Errorf("encoding/json reported error but segmentio/json did not: %w", encodingErr))
+				panic(fmt.Errorf("encoding/json reported error but segmentio/encoding did not: %w", encodingErr))
 			}
 		} else {
 			if err != nil {
-				panic(fmt.Errorf("encoding/json did not report an error but segmentio/json did: %w", err))
+				panic(fmt.Errorf("encoding/json did not report an error but segmentio/encoding did: %w", err))
 			} else {
 				// both implementations pass
 			}

--- a/json/fuzz/fuzz.go
+++ b/json/fuzz/fuzz.go
@@ -34,22 +34,32 @@ func Fuzz(data []byte) int {
 		// standard encoding/json package, whether it's right or wrong.
 		v1 := ctor()
 		v2 := ctor()
-		encodingErr := encodingJSON.Unmarshal(data, v1)
-		err := json.Unmarshal(data, v2)
 
-		if encodingErr != nil {
-			if err != nil {
+		err1 := encodingJSON.Unmarshal(data, v1)
+		err2 := json.Unmarshal(data, v2)
+
+		if err1 != nil {
+			if err2 != nil {
 				// both implementations report an error
-				if reflect.TypeOf(encodingErr) != reflect.TypeOf(err) {
-					panic(fmt.Errorf("error types mismatch: encoding/json=%T segmentio/encoding=%T", encodingErr, err))
+				if reflect.TypeOf(err1) != reflect.TypeOf(err2) {
+					fmt.Printf("input: %s\n", string(data))
+					fmt.Printf("encoding/json.Unmarshal(%T): %T: %s\n", v1, err1, err1)
+					fmt.Printf("segmentio/encoding/json.Unmarshal(%T): %T: %s\n", v2, err2, err2)
+					panic("error types mismatch")
 				}
 				continue
 			} else {
-				panic(fmt.Errorf("encoding/json reported error but segmentio/encoding did not: %w", encodingErr))
+				fmt.Printf("input: %s\n", string(data))
+				fmt.Printf("encoding/json.Unmarshal(%T): %T: %s\n", v1, err1, err1)
+				fmt.Printf("segmentio/encoding/json.Unmarshal(%T): <nil>\n")
+				panic("error values mismatch")
 			}
 		} else {
-			if err != nil {
-				panic(fmt.Errorf("encoding/json did not report an error but segmentio/encoding did: %w", err))
+			if err2 != nil {
+				fmt.Printf("input: %s\n", string(data))
+				fmt.Printf("encoding/json.Unmarshal(%T): <nil>\n")
+				fmt.Printf("segmentio/encoding/json.Unmarshal(%T): %T: %s\n", v2, err2, err2)
+				panic("error values mismatch")
 			} else {
 				// both implementations pass
 			}

--- a/json/golang_decode_test.go
+++ b/json/golang_decode_test.go
@@ -456,20 +456,20 @@ var unmarshalTests = []unmarshalTest{
 	{in: `{"alphabet": "xyz"}`, ptr: new(U), err: fmt.Errorf("json: unknown field \"alphabet\""), disallowUnknownFields: true},
 
 	// syntax errors
-	{in: `{"X": "foo", "Y"}`, err: &SyntaxError{"invalid character '}' after object key", 17}},
-	{in: `[1, 2, 3+]`, err: &SyntaxError{"invalid character '+' after array element", 9}},
-	{in: `{"X":12x}`, err: &SyntaxError{"invalid character 'x' after object key:value pair", 8}, useNumber: true},
-	{in: `[2, 3`, err: &SyntaxError{msg: "unexpected end of JSON input", Offset: 5}},
+	{in: `{"X": "foo", "Y"}`, err: &testSyntaxError{"invalid character '}' after object key", 17}},
+	{in: `[1, 2, 3+]`, err: &testSyntaxError{"invalid character '+' after array element", 9}},
+	{in: `{"X":12x}`, err: &testSyntaxError{"invalid character 'x' after object key:value pair", 8}, useNumber: true},
+	{in: `[2, 3`, err: &testSyntaxError{msg: "unexpected end of JSON input", Offset: 5}},
 
 	// raw value errors
-	{in: "\x01 42", err: &SyntaxError{"invalid character '\\x01' looking for beginning of value", 1}},
-	{in: " 42 \x01", err: &SyntaxError{"invalid character '\\x01' after top-level value", 5}},
-	{in: "\x01 true", err: &SyntaxError{"invalid character '\\x01' looking for beginning of value", 1}},
-	{in: " false \x01", err: &SyntaxError{"invalid character '\\x01' after top-level value", 8}},
-	{in: "\x01 1.2", err: &SyntaxError{"invalid character '\\x01' looking for beginning of value", 1}},
-	{in: " 3.4 \x01", err: &SyntaxError{"invalid character '\\x01' after top-level value", 6}},
-	{in: "\x01 \"string\"", err: &SyntaxError{"invalid character '\\x01' looking for beginning of value", 1}},
-	{in: " \"string\" \x01", err: &SyntaxError{"invalid character '\\x01' after top-level value", 11}},
+	{in: "\x01 42", err: &testSyntaxError{"invalid character '\\x01' looking for beginning of value", 1}},
+	{in: " 42 \x01", err: &testSyntaxError{"invalid character '\\x01' after top-level value", 5}},
+	{in: "\x01 true", err: &testSyntaxError{"invalid character '\\x01' looking for beginning of value", 1}},
+	{in: " false \x01", err: &testSyntaxError{"invalid character '\\x01' after top-level value", 8}},
+	{in: "\x01 1.2", err: &testSyntaxError{"invalid character '\\x01' looking for beginning of value", 1}},
+	{in: " 3.4 \x01", err: &testSyntaxError{"invalid character '\\x01' after top-level value", 6}},
+	{in: "\x01 \"string\"", err: &testSyntaxError{"invalid character '\\x01' looking for beginning of value", 1}},
+	{in: " \"string\" \x01", err: &testSyntaxError{"invalid character '\\x01' after top-level value", 11}},
 
 	// array tests
 	{in: `[1, 2, 3]`, ptr: new([3]int), out: [3]int{1, 2, 3}},

--- a/json/golang_scanner_test.go
+++ b/json/golang_scanner_test.go
@@ -182,8 +182,8 @@ type indentErrorTest struct {
 }
 
 var indentErrorTests = []indentErrorTest{
-	{`{"X": "foo", "Y"}`, &SyntaxError{"invalid character '}' after object key", 17}},
-	{`{"X": "foo" "Y": "bar"}`, &SyntaxError{"invalid character '\"' after object key:value pair", 13}},
+	{`{"X": "foo", "Y"}`, &testSyntaxError{"invalid character '}' after object key", 17}},
+	{`{"X": "foo" "Y": "bar"}`, &testSyntaxError{"invalid character '\"' after object key:value pair", 13}},
 }
 
 func TestIndentErrors(t *testing.T) {

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -992,7 +992,7 @@ func TestUnmarshalFuzzBugs(t *testing.T) {
 		},
 		{ // invalid base64 content when decoding string into byte slice
 			input: "{\"F\":\"0\"}",
-			value: struct{ F []uint8 }{},
+			value: struct{ F []byte }{},
 		},
 		{ // decode an object with a "null" string as key
 			input: "{\"null\":null}",
@@ -1099,6 +1099,16 @@ func TestUnmarshalFuzzBugs(t *testing.T) {
 			value: struct {
 				S int `json:",string"`
 			}{S: 3},
+		},
+		{ // decode string containing what looks like an object into integer field with string tag
+			input: "{\"S\":\"{}\"}",
+			value: struct {
+				S int `json:",string"`
+			}{},
+		},
+		{ // decode an empty string followed by the same field with a null value into a byte slice
+			input: "{\"F\":\"\",\"F\":null}",
+			value: struct{ F []byte }{},
 		},
 	}
 

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1074,6 +1074,16 @@ func TestUnmarshalFuzzBugs(t *testing.T) {
 				A int `json:",omitempty"`
 			}{},
 		},
+		{ // decode string with number followed by random byte into integer field with string tag
+			input: "{\"s\":\"0]\"}",
+			value: struct {
+				S int `json:",string"`
+			}{},
+		},
+		{ // decode object into integer field
+			input: "{\"n\":{}}",
+			value: struct{ N *int }{},
+		},
 	}
 
 	for _, test := range tests {

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -992,6 +992,16 @@ func TestUnmarshalFuzzBugs(t *testing.T) {
 				S int `json:",string"`
 			}{},
 		},
+		{ // invalid base64 content when decoding string into byte slice
+			input: "{\"F\":\"0\"}",
+			value: struct{ F []uint8 }{},
+		},
+		{ // decode an object with a "null" string as key
+			input: "{\"null\":null}",
+			value: struct {
+				S int `json:",string"`
+			}{},
+		},
 	}
 
 	for _, test := range tests {

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1064,6 +1064,16 @@ func TestUnmarshalFuzzBugs(t *testing.T) {
 				S int `json:",string"`
 			}{},
 		},
+		{
+			input: "{\"N\":-00}",
+			value: struct{ N *int }{},
+		},
+		{
+			input: "{\"a\":9223372036854775808}",
+			value: struct {
+				A int `json:",omitempty"`
+			}{},
+		},
 	}
 
 	for _, test := range tests {

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -946,6 +946,18 @@ func TestUnmarshalFuzzBugs(t *testing.T) {
 		{ // decode weird number value into nil
 			input: "-00",
 		},
+		{ // decode an invalid escaped sequence
+			input: "\"\\0\"",
+			value: "",
+		},
+		{ // decode what looks like an array followed by a number into a slice
+			input: "[9E600",
+			value: []interface{}{},
+		},
+		{ // decode a number which is too large to fit in a float64
+			input: "[1e900]",
+			value: []interface{}{},
+		},
 	}
 
 	for _, test := range tests {

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -958,6 +958,10 @@ func TestUnmarshalFuzzBugs(t *testing.T) {
 			input: "[1e900]",
 			value: []interface{}{},
 		},
+		{ // many nested arrays openings
+			input: "[[[[[[",
+			value: []interface{}{},
+		},
 	}
 
 	for _, test := range tests {

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1084,6 +1084,10 @@ func TestUnmarshalFuzzBugs(t *testing.T) {
 			input: "{\"n\":{}}",
 			value: struct{ N *int }{},
 		},
+		{ // decode negative integer into unsigned type
+			input: "{\"E\":-0}",
+			value: struct{ E uint8 }{},
+		},
 	}
 
 	for _, test := range tests {

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1000,7 +1000,7 @@ func TestUnmarshalFuzzBugs(t *testing.T) {
 				S int `json:",string"`
 			}{},
 		},
-		{ // decode a floating point number representation into an integer field with string tag
+		{ // decode an invalid floating point number representation into an integer field with string tag
 			input: "{\"s\":8e800}",
 			value: struct {
 				S int `json:",string"`
@@ -1014,6 +1014,24 @@ func TestUnmarshalFuzzBugs(t *testing.T) {
 		},
 		{ // decode non-ascii string into integer field with string tag
 			input: "{\"ſ\":\"\xbf\"}",
+			value: struct {
+				S int `json:",string"`
+			}{},
+		},
+		{ // decode a valid floating point number representation into an integer field with string tag
+			input: "{\"S\":0.0}",
+			value: struct {
+				S int `json:",string"`
+			}{},
+		},
+		{ // decode string with invalid leading sign to integer field with string tag
+			input: "{\"S\":\"+0\"}",
+			value: struct {
+				S int `json:",string"`
+			}{},
+		},
+		{ // decode string with object representation to integer field with string tag
+			input: "{\"s\":{}}",
 			value: struct {
 				S int `json:",string"`
 			}{},

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1088,6 +1088,18 @@ func TestUnmarshalFuzzBugs(t *testing.T) {
 			input: "{\"E\":-0}",
 			value: struct{ E uint8 }{},
 		},
+		{ // decode string with number followed by random byte into integer field with string tag
+			input: "{\"s\":\"03�\"}",
+			value: struct {
+				S int `json:",string"`
+			}{},
+		},
+		{ // decode string with leading zeroes into integer field with string tag
+			input: "{\"s\":\"03\"}",
+			value: struct {
+				S int `json:",string"`
+			}{S: 3},
+		},
 	}
 
 	for _, test := range tests {

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1012,6 +1012,18 @@ func TestUnmarshalFuzzBugs(t *testing.T) {
 				S int `json:",string"`
 			}{},
 		},
+		{ // decode a string with invalid leading sign and zeroes into an integer field with string tag
+			input: "{\"S\":\"+00\"}",
+			value: struct {
+				S int `json:",string"`
+			}{},
+		},
+		{ // decode a string with valid leading sign and zeroes into an integer field with string tag
+			input: "{\"S\":\"-00\"}",
+			value: struct {
+				S int `json:",string"`
+			}{},
+		},
 		{ // decode non-ascii string into integer field with string tag
 			input: "{\"ſ\":\"\xbf\"}",
 			value: struct {
@@ -1030,15 +1042,27 @@ func TestUnmarshalFuzzBugs(t *testing.T) {
 				S int `json:",string"`
 			}{},
 		},
+		{ // decode string with valid leading sign to integer field with string tag
+			input: "{\"S\":\"-0\"}",
+			value: struct {
+				S int `json:",string"`
+			}{},
+		},
 		{ // decode string with object representation to integer field with string tag
 			input: "{\"s\":{}}",
 			value: struct {
 				S int `json:",string"`
 			}{},
 		},
-		{
+		{ // decoding integer with leading zeroes
 			input: "{\"o\":00}",
 			value: struct{ O **int }{},
+		},
+		{ // codeding string with invalid float representation into integer field with string tag
+			input: "{\"s\":\"0.\"}",
+			value: struct {
+				S int `json:",string"`
+			}{},
 		},
 	}
 

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1110,8 +1110,20 @@ func TestUnmarshalFuzzBugs(t *testing.T) {
 			input: "{\"F\":\"\",\"F\":null}",
 			value: struct{ F []byte }{},
 		},
-		{ // decode string containing a flow into an integer field with string tag
+		{ // decode string containing a float into an integer field with string tag
 			input: "{\"S\":\"0e0\"}",
+			value: struct {
+				S int `json:",string"`
+			}{},
+		},
+		{ // decode string with negative sign into a an integer field with string tag
+			input: "{\"s\":\"-\"}",
+			value: struct {
+				S int `json:",string"`
+			}{},
+		},
+		{ // decode string with positive sign into a an integer field with string tag
+			input: "{\"s\":\"+\"}",
 			value: struct {
 				S int `json:",string"`
 			}{},

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1110,6 +1110,12 @@ func TestUnmarshalFuzzBugs(t *testing.T) {
 			input: "{\"F\":\"\",\"F\":null}",
 			value: struct{ F []byte }{},
 		},
+		{ // decode string containing a flow into an integer field with string tag
+			input: "{\"S\":\"0e0\"}",
+			value: struct {
+				S int `json:",string"`
+			}{},
+		},
 	}
 
 	for _, test := range tests {

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -980,11 +980,9 @@ func TestUnmarshalFuzzBugs(t *testing.T) {
 				S int `json:",string"`
 			}{},
 		},
-		{ // decode object with null key into struct
+		{ // decode object with null key into map
 			input: "{null:0}",
-			value: struct {
-				S int `json:",string"`
-			}{},
+			value: map[string]interface{}{},
 		},
 		{ // decode unquoted integer into struct field with string tag
 			input: "{\"S\":0}",
@@ -998,6 +996,12 @@ func TestUnmarshalFuzzBugs(t *testing.T) {
 		},
 		{ // decode an object with a "null" string as key
 			input: "{\"null\":null}",
+			value: struct {
+				S int `json:",string"`
+			}{},
+		},
+		{
+			input: "{\"s\":8e800}",
 			value: struct {
 				S int `json:",string"`
 			}{},

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1064,11 +1064,11 @@ func TestUnmarshalFuzzBugs(t *testing.T) {
 				S int `json:",string"`
 			}{},
 		},
-		{
+		{ // malformed negative integer in object value
 			input: "{\"N\":-00}",
 			value: struct{ N *int }{},
 		},
-		{
+		{ // integer overflow
 			input: "{\"a\":9223372036854775808}",
 			value: struct {
 				A int `json:",omitempty"`

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1000,8 +1000,20 @@ func TestUnmarshalFuzzBugs(t *testing.T) {
 				S int `json:",string"`
 			}{},
 		},
-		{
+		{ // decode a floating point number representation into an integer field with string tag
 			input: "{\"s\":8e800}",
+			value: struct {
+				S int `json:",string"`
+			}{},
+		},
+		{ // decode a string with leading zeroes into an integer field with string tag
+			input: "{\"S\":\"00\"}",
+			value: struct {
+				S int `json:",string"`
+			}{},
+		},
+		{ // decode non-ascii string into integer field with string tag
+			input: "{\"ſ\":\"\xbf\"}",
 			value: struct {
 				S int `json:",string"`
 			}{},

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -847,21 +847,15 @@ func TestUnmarshalFuzzBugs(t *testing.T) {
 		},
 		{ // decode single-element slice into []byte field
 			input: "{\"f\":[0],\"0\":[0]}",
-			value: struct {
-				F []byte
-			}{F: []byte{0}},
+			value: struct{ F []byte }{F: []byte{0}},
 		},
 		{ // decode multi-element slice into []byte field
 			input: "{\"F\":[3,1,1,1,9,9]}",
-			value: struct {
-				F []byte
-			}{F: []byte{3, 1, 1, 1, 9, 9}},
+			value: struct{ F []byte }{F: []byte{3, 1, 1, 1, 9, 9}},
 		},
 		{ // decode string with escape sequence into []byte field
 			input: "{\"F\":\"0p00\\r\"}",
-			value: struct {
-				F []byte
-			}{F: []byte("ҝ4")},
+			value: struct{ F []byte }{F: []byte("ҝ4")},
 		},
 		{ // decode unicode code points which fold into ascii characters
 			input: "{\"ſ\":\"8\"}",
@@ -871,21 +865,15 @@ func TestUnmarshalFuzzBugs(t *testing.T) {
 		},
 		{ // decode unicode code points which don't fold into ascii characters
 			input: "{\"İ\":\"\"}",
-			value: struct {
-				I map[string]string
-			}{I: nil},
+			value: struct{ I map[string]string }{I: nil},
 		},
 		{ // override pointer-to-pointer field clears the inner pointer only
 			input: "{\"o\":0,\"o\":null}",
-			value: struct {
-				O **int
-			}{O: new(*int)},
+			value: struct{ O **int }{O: new(*int)},
 		},
 		{ // subsequent occurrences of a map field retain keys previously loaded
 			input: "{\"i\":{\"\":null},\"i\":{}}",
-			value: struct {
-				I map[string]string
-			}{I: map[string]string{"": ""}},
+			value: struct{ I map[string]string }{I: map[string]string{"": ""}},
 		},
 		{ // an empty string is an invalid JSON input
 			input: "",
@@ -961,6 +949,30 @@ func TestUnmarshalFuzzBugs(t *testing.T) {
 		{ // many nested arrays openings
 			input: "[[[[[[",
 			value: []interface{}{},
+		},
+		{ // decode a map with value type mismatch and missing closing character
+			input: "{\"\":0",
+			value: map[string]string{},
+		},
+		{ // decode a struct with value type mismatch and missing closing character
+			input: "{\"E\":\"\"",
+			value: struct{ E uint8 }{},
+		},
+		{ // decode a map with value type mismatch
+			input: "{\"\":0}",
+			value: map[string]string{},
+		},
+		{ // decode number with exponent into integer field
+			input: "{\"e\":0e0}",
+			value: struct{ E uint8 }{},
+		},
+		{ // decode invalid integer representation into integer field
+			input: "{\"e\":00}",
+			value: struct{ E uint8 }{},
+		},
+		{ // decode unterminated array into byte slice
+			input: "{\"F\":[",
+			value: struct{ F []byte }{},
 		},
 	}
 

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1036,6 +1036,10 @@ func TestUnmarshalFuzzBugs(t *testing.T) {
 				S int `json:",string"`
 			}{},
 		},
+		{
+			input: "{\"o\":00}",
+			value: struct{ O **int }{},
+		},
 	}
 
 	for _, test := range tests {

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -974,6 +974,24 @@ func TestUnmarshalFuzzBugs(t *testing.T) {
 			input: "{\"F\":[",
 			value: struct{ F []byte }{},
 		},
+		{ // attempt to decode string into in
+			input: "{\"S\":\"\"}",
+			value: struct {
+				S int `json:",string"`
+			}{},
+		},
+		{ // decode object with null key into struct
+			input: "{null:0}",
+			value: struct {
+				S int `json:",string"`
+			}{},
+		},
+		{ // decode unquoted integer into struct field with string tag
+			input: "{\"S\":0}",
+			value: struct {
+				S int `json:",string"`
+			}{},
+		},
 	}
 
 	for _, test := range tests {

--- a/json/parse.go
+++ b/json/parse.go
@@ -25,17 +25,14 @@ const (
 )
 
 func skipSpaces(b []byte) []byte {
-	i := 0
-skipLoop:
-	for _, c := range b {
-		switch c {
+	for i := range b {
+		switch b[i] {
 		case sp, ht, nl, cr:
-			i++
 		default:
-			break skipLoop
+			return b[i:]
 		}
 	}
-	return b[i:]
+	return nil
 }
 
 // parseInt parses a decimanl representation of an int64 from b.

--- a/json/parse.go
+++ b/json/parse.go
@@ -61,6 +61,10 @@ func parseInt(b []byte) (int64, []byte, error) {
 			return 0, b, syntaxError(b, "cannot decode integer from '-'")
 		}
 
+		if len(b) > 2 && b[0] == '0' && '0' <= b[1] && b[1] <= '9' {
+			return 0, b, syntaxError(b, "invalid leading character '0' in integer")
+		}
+
 		for _, d := range b[1:] {
 			if !(d >= '0' && d <= '9') {
 				if count == 0 {
@@ -88,6 +92,10 @@ func parseInt(b []byte) (int64, []byte, error) {
 	} else {
 		const max = math.MaxInt64
 		const lim = max / 10
+
+		if len(b) > 2 && b[0] == '0' && '0' <= b[1] && b[1] <= '9' {
+			return 0, b, syntaxError(b, "invalid leading character '0' in integer")
+		}
 
 		for _, d := range b {
 			if !(d >= '0' && d <= '9') {
@@ -137,8 +145,8 @@ func parseUint(b []byte) (uint64, []byte, error) {
 		return 0, b, syntaxError(b, "cannot decode integer value from an empty input")
 	}
 
-	if b[0] == '0' && len(b) > 1 && '0' <= b[1] && b[1] <= '9' {
-		return 0, b, syntaxError(b, "cannot decode positive integer with leading zero")
+	if len(b) > 2 && b[0] == '0' && '0' <= b[1] && b[1] <= '9' {
+		return 0, b, syntaxError(b, "invalid leading character '0' in integer")
 	}
 
 	for _, d := range b {
@@ -279,6 +287,10 @@ func parseNumber(b []byte) (v, r []byte, err error) {
 		i++
 		if i == len(b) || (b[i] != '.' && b[i] != 'e' && b[i] != 'E') {
 			v, r = b[:i], b[i:]
+			return
+		}
+		if '0' <= b[i] && b[i] <= '9' {
+			r, err = b[i:], syntaxError(b, "cannot decode number with leading '0' character")
 			return
 		}
 	}

--- a/json/parse.go
+++ b/json/parse.go
@@ -62,7 +62,7 @@ func parseInt(b []byte, t reflect.Type) (int64, []byte, error) {
 			return 0, b, syntaxError(b, "cannot decode integer from '-'")
 		}
 
-		if len(b) > 1 && b[0] == '0' && '0' <= b[1] && b[1] <= '9' {
+		if len(b) > 2 && b[1] == '0' && '0' <= b[2] && b[2] <= '9' {
 			return 0, b, syntaxError(b, "invalid leading character '0' in integer")
 		}
 

--- a/json/parse.go
+++ b/json/parse.go
@@ -69,7 +69,8 @@ func parseInt(b []byte, t reflect.Type) (int64, []byte, error) {
 		for _, d := range b[1:] {
 			if !(d >= '0' && d <= '9') {
 				if count == 0 {
-					return 0, b, syntaxError(b, "missing digits after negative sign")
+					b, err := inputError(b, t)
+					return 0, b, err
 				}
 				break
 			}
@@ -101,7 +102,8 @@ func parseInt(b []byte, t reflect.Type) (int64, []byte, error) {
 		for _, d := range b {
 			if !(d >= '0' && d <= '9') {
 				if count == 0 {
-					return 0, b, syntaxError(b, "expected digit but found '%c'", d)
+					b, err := inputError(b, t)
+					return 0, b, err
 				}
 				break
 			}

--- a/json/parse.go
+++ b/json/parse.go
@@ -668,6 +668,17 @@ func hasPrefix(b []byte, s string) bool {
 	return len(b) >= len(s) && s == string(b[:len(s)])
 }
 
+func hasLeadingSign(b []byte) bool {
+	return len(b) > 0 && (b[0] == '+' || b[0] == '-')
+}
+
+func hasLeadingZeroes(b []byte) bool {
+	if hasLeadingSign(b) {
+		b = b[1:]
+	}
+	return len(b) > 1 && b[0] == '0' && '0' <= b[1] && b[1] <= '9'
+}
+
 func appendToLower(b, s []byte) []byte {
 	if ascii.Valid(s) { // fast path for ascii strings
 		i := 0

--- a/json/parse.go
+++ b/json/parse.go
@@ -61,10 +61,6 @@ func parseInt(b []byte) (int64, []byte, error) {
 			return 0, b, syntaxError(b, "cannot decode integer from '-'")
 		}
 
-		if b[1] == '0' && len(b) > 2 && '0' <= b[2] && b[2] <= '9' {
-			return 0, b, syntaxError(b, "cannot decode negative integer with leading zero")
-		}
-
 		for _, d := range b[1:] {
 			if !(d >= '0' && d <= '9') {
 				if count == 0 {
@@ -92,10 +88,6 @@ func parseInt(b []byte) (int64, []byte, error) {
 	} else {
 		const max = math.MaxInt64
 		const lim = max / 10
-
-		if b[0] == '0' && len(b) > 1 && '0' <= b[1] && b[1] <= '9' {
-			return 0, b, syntaxError(b, "cannot decode positive integer with leading zero")
-		}
 
 		for _, d := range b {
 			if !(d >= '0' && d <= '9') {

--- a/json/parse.go
+++ b/json/parse.go
@@ -75,14 +75,14 @@ func parseInt(b []byte, t reflect.Type) (int64, []byte, error) {
 			}
 
 			if value < lim {
-				return 0, b, syntaxError(b, "integer value out of range")
+				return 0, b, unmarshalOverflow(b, t)
 			}
 
 			value *= 10
 			x := int64(d - '0')
 
 			if value < (max + x) {
-				return 0, b, syntaxError(b, "integer value out of range")
+				return 0, b, unmarshalOverflow(b, t)
 			}
 
 			value -= x
@@ -108,11 +108,11 @@ func parseInt(b []byte, t reflect.Type) (int64, []byte, error) {
 			x := int64(d - '0')
 
 			if value > lim {
-				return 0, b, syntaxError(b, "integer value out of range")
+				return 0, b, unmarshalOverflow(b, t)
 			}
 
 			if value *= 10; value > (max - x) {
-				return 0, b, syntaxError(b, "integer value out of range")
+				return 0, b, unmarshalOverflow(b, t)
 			}
 
 			value += x
@@ -160,11 +160,11 @@ func parseUint(b []byte, t reflect.Type) (uint64, []byte, error) {
 		x := uint64(d - '0')
 
 		if value > lim {
-			return 0, b, syntaxError(b, "integer value out of range")
+			return 0, b, unmarshalOverflow(b, t)
 		}
 
 		if value *= 10; value > (max - x) {
-			return 0, b, syntaxError(b, "integer value out of range")
+			return 0, b, unmarshalOverflow(b, t)
 		}
 
 		value += x

--- a/json/parse.go
+++ b/json/parse.go
@@ -155,7 +155,8 @@ func parseUint(b []byte, t reflect.Type) (uint64, []byte, error) {
 	for _, d := range b {
 		if !(d >= '0' && d <= '9') {
 			if count == 0 {
-				return 0, b, syntaxError(b, "expected digit but found '%c'", d)
+				b, err := inputError(b, t)
+				return 0, b, err
 			}
 			break
 		}

--- a/json/token.go
+++ b/json/token.go
@@ -129,7 +129,7 @@ func (t *Tokenizer) Next() bool {
 skipLoop:
 	for _, c := range t.json {
 		switch c {
-		case sp, ht, nl, cr, np, bs:
+		case sp, ht, nl, cr:
 			i++
 		default:
 			break skipLoop


### PR DESCRIPTION
Ref: https://github.com/segmentio/encoding/issues/3

Running this briefly locally reported some errors. For example, given the input `["\b"]` (backspace char in string), `encoding/json` reports an error, but `segmentio/encoding/json` accepts it.