### PR TITLE
optimize null, true, and false prefix checks

### DIFF
--- a/json/decode.go
+++ b/json/decode.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (d decoder) decodeNull(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 	return b, unmarshalTypeError(b, nullType)
@@ -22,15 +22,15 @@ func (d decoder) decodeNull(b []byte, p unsafe.Pointer) ([]byte, error) {
 
 func (d decoder) decodeBool(b []byte, p unsafe.Pointer) ([]byte, error) {
 	switch {
-	case hasPrefix(b, "true"):
+	case hasTruePrefix(b):
 		*(*bool)(p) = true
 		return b[4:], nil
 
-	case hasPrefix(b, "false"):
+	case hasFalsePrefix(b):
 		*(*bool)(p) = false
 		return b[5:], nil
 
-	case hasPrefix(b, "null"):
+	case hasNullPrefix(b):
 		return b[4:], nil
 
 	default:
@@ -39,7 +39,7 @@ func (d decoder) decodeBool(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeInt(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
@@ -53,7 +53,7 @@ func (d decoder) decodeInt(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeInt8(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
@@ -71,7 +71,7 @@ func (d decoder) decodeInt8(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeInt16(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
@@ -89,7 +89,7 @@ func (d decoder) decodeInt16(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeInt32(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
@@ -107,7 +107,7 @@ func (d decoder) decodeInt32(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeInt64(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
@@ -121,7 +121,7 @@ func (d decoder) decodeInt64(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeUint(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
@@ -135,7 +135,7 @@ func (d decoder) decodeUint(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeUintptr(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
@@ -149,7 +149,7 @@ func (d decoder) decodeUintptr(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeUint8(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
@@ -167,7 +167,7 @@ func (d decoder) decodeUint8(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeUint16(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
@@ -185,7 +185,7 @@ func (d decoder) decodeUint16(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeUint32(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
@@ -203,7 +203,7 @@ func (d decoder) decodeUint32(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeUint64(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
@@ -217,7 +217,7 @@ func (d decoder) decodeUint64(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeFloat32(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
@@ -236,7 +236,7 @@ func (d decoder) decodeFloat32(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeFloat64(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
@@ -255,7 +255,7 @@ func (d decoder) decodeFloat64(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeNumber(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
@@ -274,7 +274,7 @@ func (d decoder) decodeNumber(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeString(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
@@ -293,7 +293,7 @@ func (d decoder) decodeString(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeFromString(b []byte, p unsafe.Pointer, decode decodeFunc) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return decode(d, b, p)
 	}
 
@@ -314,7 +314,7 @@ func (d decoder) decodeFromString(b []byte, p unsafe.Pointer, decode decodeFunc)
 }
 
 func (d decoder) decodeBytes(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
@@ -345,7 +345,7 @@ func (d decoder) decodeBytes(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeDuration(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
@@ -388,7 +388,7 @@ func (d decoder) decodeDuration(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeTime(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
@@ -413,7 +413,7 @@ func (d decoder) decodeTime(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeArray(b []byte, p unsafe.Pointer, n int, size uintptr, t reflect.Type, decode decodeFunc) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 
@@ -474,7 +474,7 @@ func (d decoder) decodeArray(b []byte, p unsafe.Pointer, n int, size uintptr, t 
 }
 
 func (d decoder) decodeSlice(b []byte, p unsafe.Pointer, size uintptr, t reflect.Type, decode decodeFunc) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		*(*slice)(p) = slice{}
 		return b[4:], nil
 	}
@@ -543,7 +543,7 @@ func (d decoder) decodeSlice(b []byte, p unsafe.Pointer, size uintptr, t reflect
 }
 
 func (d decoder) decodeMap(b []byte, p unsafe.Pointer, t, kt, vt reflect.Type, kz, vz reflect.Value, decodeKey, decodeValue decodeFunc) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		*(*unsafe.Pointer)(p) = nil
 		return b[4:], nil
 	}
@@ -614,7 +614,7 @@ func (d decoder) decodeMap(b []byte, p unsafe.Pointer, t, kt, vt reflect.Type, k
 }
 
 func (d decoder) decodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		*(*unsafe.Pointer)(p) = nil
 		return b[4:], nil
 	}
@@ -685,7 +685,7 @@ func (d decoder) decodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, e
 }
 
 func (d decoder) decodeMapStringRawMessage(b []byte, p unsafe.Pointer) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		*(*unsafe.Pointer)(p) = nil
 		return b[4:], nil
 	}
@@ -756,7 +756,7 @@ func (d decoder) decodeMapStringRawMessage(b []byte, p unsafe.Pointer) ([]byte, 
 }
 
 func (d decoder) decodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
 	if len(b) < 2 || b[0] != '{' {
@@ -846,7 +846,7 @@ func (d decoder) decodeEmbeddedStructPointer(b []byte, p unsafe.Pointer, t refle
 }
 
 func (d decoder) decodePointer(b []byte, p unsafe.Pointer, t reflect.Type, decode decodeFunc) ([]byte, error) {
-	if hasPrefix(b, "null") {
+	if hasNullPrefix(b) {
 		pp := *(*unsafe.Pointer)(p)
 		if pp != nil && t.Kind() == reflect.Ptr {
 			return decode(d, b, pp)
@@ -873,7 +873,7 @@ func (d decoder) decodeInterface(b []byte, p unsafe.Pointer) ([]byte, error) {
 			// If the destination is nil the only value that is OK to decode is
 			// `null`, and the encoding/json package always nils the destination
 			// interface value in this case.
-			if hasPrefix(b, "null") {
+			if hasNullPrefix(b) {
 				*(*interface{})(p) = nil
 				return b[4:], nil
 			}

--- a/json/parse_test.go
+++ b/json/parse_test.go
@@ -106,3 +106,30 @@ func BenchmarkAppendToLower(b *testing.B) {
 		a = appendToLower(a[:0], s)
 	}
 }
+
+var benchmarkHasPrefixString = []byte("some random string")
+var benchmarkHasPrefixResult = false
+
+func BenchmarkHasPrefix(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		benchmarkHasPrefixResult = hasPrefix(benchmarkHasPrefixString, "null")
+	}
+}
+
+func BenchmarkHasNullPrefix(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		benchmarkHasPrefixResult = hasNullPrefix(benchmarkHasPrefixString)
+	}
+}
+
+func BenchmarkHasTruePrefix(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		benchmarkHasPrefixResult = hasTruePrefix(benchmarkHasPrefixString)
+	}
+}
+
+func BenchmarkHasFalsePrefix(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		benchmarkHasPrefixResult = hasFalsePrefix(benchmarkHasPrefixString)
+	}
+}


### PR DESCRIPTION
This is an interesting one because one could assume that the compiler should be able to optimize the code away on its own, but apparently it doesn't, using `hasPrefix(s, "null")` is ~4x slower than the equivalent `hasNullPrefix(s)` function, even if both versions get inlined:
```
BenchmarkHasPrefix              421709948                2.80 ns/op            0 B/op          0 allocs/op
BenchmarkHasNullPrefix          1000000000               0.688 ns/op           0 B/op          0 allocs/op
BenchmarkHasTruePrefix          1000000000               0.694 ns/op           0 B/op          0 allocs/op
BenchmarkHasFalsePrefix         1000000000               0.861 ns/op           0 B/op          0 allocs/op
```
I looked a little deeper into the assembly to see what's going on, here are two equivalent programs, one calling `hasPrefix` and the second calling `hasNullPrefix`:
```
TEXT main.main(SB) /tmp/hasprefix.go
  hasprefix.go:14	0x10512e0		65488b0c2530000000	MOVQ GS:0x30, CX
  hasprefix.go:14	0x10512e9		483b6110		CMPQ 0x10(CX), SP
  hasprefix.go:14	0x10512ed		7656			JBE 0x1051345
  hasprefix.go:14	0x10512ef		4883ec28		SUBQ $0x28, SP
  hasprefix.go:14	0x10512f3		48896c2420		MOVQ BP, 0x20(SP)
  hasprefix.go:14	0x10512f8		488d6c2420		LEAQ 0x20(SP), BP
  hasprefix.go:16	0x10512fd		488b057cfb0600		MOVQ main.s(SB), AX
  hasprefix.go:16	0x1051304		48833d7cfb060004	CMPQ $0x4, main.s+8(SB)
  hasprefix.go:8	0x105130c		7d12			JGE 0x1051320
  hasprefix.go:8	0x105130e		31c0			XORL AX, AX
  hasprefix.go:16	0x1051310		8805abc90800		MOVB AL, main.i(SB)
  hasprefix.go:17	0x1051316		488b6c2420		MOVQ 0x20(SP), BP
  hasprefix.go:17	0x105131b		4883c428		ADDQ $0x28, SP
  hasprefix.go:17	0x105131f		c3			RET
  hasprefix.go:8	0x1051320		488d0d2ef90100		LEAQ go.string.*+245(SB), CX
  hasprefix.go:8	0x1051327		48890c24		MOVQ CX, 0(SP)
  hasprefix.go:8	0x105132b		4889442408		MOVQ AX, 0x8(SP)
  hasprefix.go:8	0x1051330		48c744241004000000	MOVQ $0x4, 0x10(SP)
  hasprefix.go:8	0x1051339		e8220ffbff		CALL runtime.memequal(SB)
  hasprefix.go:8	0x105133e		0fb6442418		MOVZX 0x18(SP), AX
  hasprefix.go:8	0x1051343		ebcb			JMP 0x1051310
  hasprefix.go:14	0x1051345		e84681ffff		CALL runtime.morestack_noctxt(SB)
  hasprefix.go:14	0x105134a		eb94			JMP main.main(SB)
```
```
TEXT main.main(SB) /tmp/hasprefix.go
  hasprefix.go:15	0x10512e0		488b0599fb0600		MOVQ main.s(SB), AX
  hasprefix.go:15	0x10512e7		48833d99fb060004	CMPQ $0x4, main.s+8(SB)
  hasprefix.go:4	0x10512ef		7c10			JL 0x1051301
  hasprefix.go:4	0x10512f1		81386e756c6c		CMPL $0x6c6c756e, 0(AX)
  hasprefix.go:4	0x10512f7		0f94c0			SETE AL
  hasprefix.go:15	0x10512fa		8805c1c90800		MOVB AL, main.i(SB)
  hasprefix.go:17	0x1051300		c3			RET
  hasprefix.go:17	0x1051301		31c0			XORL AX, AX
  hasprefix.go:4	0x1051303		ebf5			JMP 0x10512fa
```
So it appears the compiler turns this into a simple 32 bits comparison without calling `runtime.memequal`.

The `hasFalsePrefix` function checks for a 5 byte prefix, so it's a bit slower but the compiler can still inline it into an optimized comparison:
```
TEXT main.main(SB) /tmp/hasprefix.go
  hasprefix.go:15	0x10512e0		488b0599fb0600		MOVQ main.s(SB), AX
  hasprefix.go:15	0x10512e7		48833d99fb060005	CMPQ $0x5, main.s+8(SB)
  hasprefix.go:4	0x10512ef		7c1a			JL 0x105130b
  hasprefix.go:4	0x10512f1		81386e756c6c		CMPL $0x6c6c756e, 0(AX)
  hasprefix.go:4	0x10512f7		750e			JNE 0x1051307
  hasprefix.go:4	0x10512f9		80780465		CMPB $0x65, 0x4(AX)
  hasprefix.go:4	0x10512fd		0f94c0			SETE AL
  hasprefix.go:15	0x1051300		8805bbc90800		MOVB AL, main.i(SB)
  hasprefix.go:17	0x1051306		c3			RET
  hasprefix.go:17	0x1051307		31c0			XORL AX, AX
  hasprefix.go:4	0x1051309		ebf5			JMP 0x1051300
  hasprefix.go:4	0x105130b		31c0			XORL AX, AX
  hasprefix.go:4	0x105130d		ebf1			JMP 0x1051300
```
Overall this small change seems to make decoding a little bit faster, I guess checking that a JSON value is `null` happens quite often 🤷‍♂:
```
benchmark                                  old ns/op     new ns/op     delta
BenchmarkUnmarshal/*json.codeResponse2     7387825       7195949       -2.60%

benchmark                                  old MB/s     new MB/s     speedup
BenchmarkUnmarshal/*json.codeResponse2     262.66       269.66       1.03x
```