### PR TITLE
fix issue 11

### DIFF
--- a/json/encode.go
+++ b/json/encode.go
@@ -79,8 +79,11 @@ func (e encoder) encodeFloat64(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (e encoder) encodeFloat(b []byte, f float64, bits int) ([]byte, error) {
-	if math.IsNaN(f) || math.IsInf(f, 0) {
-		return b, &UnsupportedValueError{Value: reflect.ValueOf(f), Str: "unsupported value"}
+	switch {
+	case math.IsNaN(f):
+		return b, &UnsupportedValueError{Value: reflect.ValueOf(f), Str: "NaN"}
+	case math.IsInf(f, 0):
+		return b, &UnsupportedValueError{Value: reflect.ValueOf(f), Str: "inf"}
 	}
 
 	// Convert as if by ES6 number to string conversion.

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1188,3 +1188,19 @@ func (m *testMarshaller) MarshalJSON() ([]byte, error) {
 func (m *testMarshaller) UnmarshalJSON(data []byte) error {
 	return Unmarshal(data, &m.v)
 }
+
+func TestGithubIssue11(t *testing.T) {
+	// https://github.com/segmentio/encoding/issues/11
+	v := struct{ F float64 }{
+		F: math.NaN(),
+	}
+
+	_, err := Marshal(v)
+	if err == nil {
+		t.Error("no error returned when marshalling NaN value")
+	} else if s := err.Error(); !strings.Contains(s, "NaN") {
+		t.Error("error returned when marshalling NaN value does not mention 'NaN':", s)
+	} else {
+		t.Log(s)
+	}
+}


### PR DESCRIPTION
Fixes #11 

```
=== RUN   TestGithubIssue11
--- PASS: TestGithubIssue11 (0.00s)
    json_test.go:1204: json: unsupported value: NaN
PASS
ok      github.com/segmentio/encoding/json      0.528s
```