### PR TITLE
fix issue 13

### DIFF
--- a/json/codec.go
+++ b/json/codec.go
@@ -172,6 +172,9 @@ func constructCodec(t reflect.Type, seen map[reflect.Type]*structType) (c codec)
 
 	case reflect.Ptr:
 		c = constructPointerCodec(t, seen)
+
+	default:
+		c = constructUnsupportedTypeCodec(t)
 	}
 
 	p := reflect.PtrTo(t)
@@ -196,14 +199,6 @@ func constructCodec(t reflect.Type, seen map[reflect.Type]*structType) (c codec)
 
 	case p.Implements(textUnmarshalerType):
 		c.decode = constructTextUnmarshalerDecodeFunc(t, true)
-	}
-
-	if c.encode == nil {
-		c.encode = constructUnsupportedTypeEncodeFunc(t)
-	}
-
-	if c.decode == nil {
-		c.decode = constructUnsupportedTypeDecodeFunc(t)
 	}
 
 	return

--- a/json/encode.go
+++ b/json/encode.go
@@ -592,7 +592,7 @@ func (e encoder) encodeInterface(b []byte, p unsafe.Pointer) ([]byte, error) {
 	return Append(b, *(*interface{})(p), e.flags)
 }
 
-func (e encoder) encodeUnsupportedType(b []byte, p unsafe.Pointer, t reflect.Type) ([]byte, error) {
+func (e encoder) encodeUnsupportedTypeError(b []byte, p unsafe.Pointer, t reflect.Type) ([]byte, error) {
 	return b, &UnsupportedTypeError{Type: t}
 }
 


### PR DESCRIPTION
Fixes #13 

The `encoding/json` package does a bit of special magic when it comes to decoding into non-empty interface types:
- if the underlying value is nil it always accepts the `null` value but refuses everything else
- if the underlying value is a non-nill pointer type it will attempt to decode JSON into the value
