### PR TITLE
fix issue 15

### DIFF
--- a/json/codec.go
+++ b/json/codec.go
@@ -376,7 +376,7 @@ func constructMapCodec(t reflect.Type, seen map[reflect.Type]*structType) codec 
 			kc = constructStringCodec(k, seen, false)
 
 			sortKeys = func(keys []reflect.Value) {
-				sort.Slice(keys, func(i, j int) bool { return keys[i].Int() < keys[j].Int() })
+				sort.Slice(keys, func(i, j int) bool { return intStringsAreSorted(keys[i].Int(), keys[j].Int()) })
 			}
 
 		case reflect.Uint,
@@ -388,7 +388,7 @@ func constructMapCodec(t reflect.Type, seen map[reflect.Type]*structType) codec 
 			kc = constructStringCodec(k, seen, false)
 
 			sortKeys = func(keys []reflect.Value) {
-				sort.Slice(keys, func(i, j int) bool { return keys[i].Uint() < keys[j].Uint() })
+				sort.Slice(keys, func(i, j int) bool { return uintStringsAreSorted(keys[i].Uint(), keys[j].Uint()) })
 			}
 
 		default:
@@ -977,6 +977,16 @@ func prefix(b []byte) string {
 		return string(b)
 	}
 	return string(b[:32]) + "..."
+}
+
+func intStringsAreSorted(i0, i1 int64) bool {
+	var b0, b1 [32]byte
+	return string(strconv.AppendInt(b0[:0], i0, 10)) < string(strconv.AppendInt(b1[:0], i1, 10))
+}
+
+func uintStringsAreSorted(u0, u1 uint64) bool {
+	var b0, b1 [32]byte
+	return string(strconv.AppendUint(b0[:0], u0, 10)) < string(strconv.AppendUint(b1[:0], u1, 10))
 }
 
 //go:nosplit

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -187,7 +187,7 @@ var testValues = [...]interface{}{
 	makeMapStringInterface(0),
 	makeMapStringInterface(15),
 	makeMapStringInterface(1020),
-	map[uint]bool{1: false, 42: true},
+	map[int]bool{1: false, 42: true},
 	map[textValue]bool{{1, 2}: true, {3, 4}: false},
 	map[string]*point{
 		"A": {1, 2},

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -187,7 +187,7 @@ var testValues = [...]interface{}{
 	makeMapStringInterface(0),
 	makeMapStringInterface(15),
 	makeMapStringInterface(1020),
-	map[int]bool{1: false, 42: true},
+	map[uint]bool{1: false, 42: true},
 	map[textValue]bool{{1, 2}: true, {3, 4}: false},
 	map[string]*point{
 		"A": {1, 2},
@@ -1247,6 +1247,32 @@ func TestGithubIssue13(t *testing.T) {
 	v = Issue13{Stringer: &s}
 	if err := Unmarshal([]byte(`{"Stringer":"whatever"}`), &v); err != nil {
 		t.Error("unexpected error decoding string value into pointer fmt.Stringer:", err)
+	}
+}
+
+func TestGithubIssue15(t *testing.T) {
+	// https://github.com/segmentio/encoding/issues/15
+	tests := []struct {
+		m interface{}
+		s string
+	}{
+		{
+			m: map[uint]bool{1: true, 123: true, 333: true, 42: true},
+			s: `{"1":true,"123":true,"333":true,"42":true}`,
+		},
+		{
+			m: map[int]bool{-1: true, -123: true, 333: true, 42: true},
+			s: `{"-1":true,"-123":true,"333":true,"42":true}`,
+		},
+	}
+
+	for _, test := range tests {
+		b, _ := json.Marshal(test.m)
+
+		if string(b) != test.s {
+			t.Error("map with integer keys must be ordered by their string representation, got", string(b))
+		}
+
 	}
 }
 


### PR DESCRIPTION
Fixes #15 

Matches the `encoding/json` behavior when marshaling maps with integer keys into JSON objects:
https://golang.org/pkg/encoding/json/#Marshal
```
- integer keys are converted to strings
```
This is probably not the fastest way to do this but it is a minimal change that produces the correct result and doesn't cause heap allocations, we can make it faster later if needed.