### PR TITLE
Optimize slice decoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ go-fuzz-dep := ${GOPATH}/src/github.com/dvyukov/go-fuzz/go-fuzz-dep
 test:
 	go test -v -cover ./ascii
 	go test -v -cover ./json
+	go test -v -cover -tags go1.14 ./json
 	go test -v -cover ./iso8601
 	go run ./json/bugs/issue11/main.go
 	go run ./json/bugs/issue18/main.go

--- a/json/decode.go
+++ b/json/decode.go
@@ -564,6 +564,11 @@ func (d decoder) decodeArray(b []byte, p unsafe.Pointer, n int, size uintptr, t 
 	}
 }
 
+var (
+	// This is a placeholder used to consturct non-nil empty slices.
+	empty struct{}
+)
+
 func (d decoder) decodeSlice(b []byte, p unsafe.Pointer, size uintptr, t reflect.Type, decode decodeFunc) ([]byte, error) {
 	if hasNullPrefix(b) {
 		*(*slice)(p) = slice{}
@@ -620,10 +625,12 @@ func (d decoder) decodeSlice(b []byte, p unsafe.Pointer, size uintptr, t reflect
 				c *= 2
 			}
 
-			v := reflect.MakeSlice(t, s.len, c)
-			reflect.Copy(v, reflect.NewAt(t, p).Elem())
+			arrayType := reflect.ArrayOf(c, t.Elem())
+			arrayData := reflect.New(arrayType)
+			reflect.Copy(arrayData.Elem(), reflect.NewAt(t, p).Elem())
 
-			*s = *(*slice)((*iface)(unsafe.Pointer(&v)).ptr)
+			s.data = unsafe.Pointer(arrayData.Pointer())
+			s.cap = c
 		}
 
 		b, err = decode(d, b, unsafe.Pointer(uintptr(s.data)+(uintptr(s.len)*size)))
@@ -1189,8 +1196,3 @@ func (d decoder) decodeTextUnmarshaler(b []byte, p unsafe.Pointer, t reflect.Typ
 
 	return b, &UnmarshalTypeError{Value: value, Type: reflect.PtrTo(t)}
 }
-
-var (
-	// This is a placeholder used to consturct non-nil empty slices.
-	empty struct{}
-)

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1190,7 +1190,6 @@ func BenchmarkEasyjsonUnmarshalSmallStruct(b *testing.B) {
 		UserMentions []*string `json:"user_mentions"`
 	}
 
-	//var json = []byte(`{"hashtags":[{"indices":[5, 10],"text":"some-text"}],"urls":[],"user_mentions":[]}`)
 	var json = []byte(`{"hashtags":[{"indices":[5, 10],"text":"some-text"}],"urls":[],"user_mentions":[]}`)
 
 	for i := 0; i < b.N; i++ {

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1177,6 +1177,30 @@ func TestUnmarshalFuzzBugs(t *testing.T) {
 	}
 }
 
+func BenchmarkEasyjsonUnmarshalSmallStruct(b *testing.B) {
+	type Hashtag struct {
+		Indices []int  `json:"indices"`
+		Text    string `json:"text"`
+	}
+
+	//easyjson:json
+	type Entities struct {
+		Hashtags     []Hashtag `json:"hashtags"`
+		Urls         []*string `json:"urls"`
+		UserMentions []*string `json:"user_mentions"`
+	}
+
+	//var json = []byte(`{"hashtags":[{"indices":[5, 10],"text":"some-text"}],"urls":[],"user_mentions":[]}`)
+	var json = []byte(`{"hashtags":[{"indices":[5, 10],"text":"some-text"}],"urls":[],"user_mentions":[]}`)
+
+	for i := 0; i < b.N; i++ {
+		var value Entities
+		if err := Unmarshal(json, &value); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 type testMarshaller struct {
 	v string
 }

--- a/json/reflect.go
+++ b/json/reflect.go
@@ -8,9 +8,9 @@ import (
 )
 
 func extendSlice(t reflect.Type, s *slice, n int) slice {
-	arrayType := reflect.ArrayOf(t.Elem(), n)
+	arrayType := reflect.ArrayOf(n, t.Elem())
 	arrayData := reflect.New(arrayType)
-	reflect.Copy(arrayData.Elem(), reflect.NewAt(t, unsafe.Pointer(s)))
+	reflect.Copy(arrayData.Elem(), reflect.NewAt(t, unsafe.Pointer(s)).Elem())
 	return slice{
 		data: unsafe.Pointer(arrayData.Pointer()),
 		len:  s.len,

--- a/json/reflect.go
+++ b/json/reflect.go
@@ -1,0 +1,19 @@
+// +build go1.14
+
+package json
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+func extendSlice(t reflect.Type, s *slice, n int) slice {
+	arrayType := reflect.ArrayOf(t.Elem(), n)
+	arrayData := reflect.New(arrayType)
+	reflect.Copy(arrayData.Elem(), reflect.NewAt(t, unsafe.Pointer(s)))
+	return slice{
+		data: unsafe.Pointer(arrayData.Pointer()),
+		len:  s.len,
+		cap:  n,
+	}
+}

--- a/json/reflect_optimize.go
+++ b/json/reflect_optimize.go
@@ -1,0 +1,29 @@
+// +build !go1.14
+
+package json
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+//go:linkname unsafe_NewArray reflect.unsafe_NewArray
+func unsafe_NewArray(rtype unsafe.Pointer, length int) unsafe.Pointer
+
+//go:linkname typedslicecopy reflect.typedslicecopy
+//go:noescape
+func typedslicecopy(elemType unsafe.Pointer, dst, src slice) int
+
+func extendSlice(t reflect.Type, s *slice, n int) slice {
+	elemTypeRef := t.Elem()
+	elemTypePtr := ((*iface)(unsafe.Pointer(&elemTypeRef))).ptr
+
+	d := slice{
+		data: unsafe_NewArray(elemTypePtr, n),
+		len:  s.len,
+		cap:  n,
+	}
+
+	typedslicecopy(elemTypePtr, d, *s)
+	return d
+}


### PR DESCRIPTION
I tested this package against the easyjson benchmarks and there was one benchmark where we were significantly slower. After digging further it appeared to be related to calling `reflect.MakeSlice`, which forces an intermediary heap allocation to store the slice value in a `reflect.Value`. Decoders that use code generation can call `make` to construct slices and avoid this cost.

The first commit in this PR shows how to reduce the number of heap allocations while still using the `reflect.` package (and therefore guaranteeing forward compatibility), the second commit makes a direct call to `unsafe_NewArray`. Here are the diff for each code change compared to master:
```
name                          old time/op    new time/op    delta
EasyjsonUnmarshalSmallStruct    1.11µs ± 2%    1.19µs ± 2%   +6.78%  (p=0.000 n=10+10)

name                          old alloc/op   new alloc/op   delta
EasyjsonUnmarshalSmallStruct      656B ± 0%      592B ± 0%   -9.76%  (p=0.000 n=10+10)

name                          old allocs/op  new allocs/op  delta
EasyjsonUnmarshalSmallStruct      6.00 ± 0%      4.00 ± 0%  -33.33%  (p=0.000 n=10+10)
```
```
name                          old time/op    new time/op    delta
EasyjsonUnmarshalSmallStruct    1.11µs ± 2%    0.91µs ± 2%  -17.87%  (p=0.000 n=10+10)

name                          old alloc/op   new alloc/op   delta
EasyjsonUnmarshalSmallStruct      656B ± 0%      592B ± 0%   -9.76%  (p=0.000 n=10+10)

name                          old allocs/op  new allocs/op  delta
EasyjsonUnmarshalSmallStruct      6.00 ± 0%      4.00 ± 0%  -33.33%  (p=0.000 n=10+10)
```