### PR TITLE
fix issue 28

### DIFF
--- a/json/codec.go
+++ b/json/codec.go
@@ -156,7 +156,7 @@ func constructCodec(t reflect.Type, seen map[reflect.Type]*structType, canAddr b
 		c = codec{encode: encoder.encodeString, decode: decoder.decodeString}
 
 	case reflect.Interface:
-		c = codec{encode: encoder.encodeInterface, decode: constructMaybeEmptyInterfaceDecoderFunc(t)}
+		c = constructInterfaceCodec(t)
 
 	case reflect.Array:
 		c = constructArrayCodec(t, seen, canAddr)
@@ -708,6 +708,19 @@ func constructPointerEncodeFunc(t reflect.Type, encode encodeFunc) encodeFunc {
 func constructPointerDecodeFunc(t reflect.Type, decode decodeFunc) decodeFunc {
 	return func(d decoder, b []byte, p unsafe.Pointer) ([]byte, error) {
 		return d.decodePointer(b, p, t, decode)
+	}
+}
+
+func constructInterfaceCodec(t reflect.Type) codec {
+	return codec{
+		encode: constructMaybeEmptyInterfaceEncoderFunc(t),
+		decode: constructMaybeEmptyInterfaceDecoderFunc(t),
+	}
+}
+
+func constructMaybeEmptyInterfaceEncoderFunc(t reflect.Type) encodeFunc {
+	return func(e encoder, b []byte, p unsafe.Pointer) ([]byte, error) {
+		return e.encodeMaybeEmptyInterface(b, p, t)
 	}
 }
 

--- a/json/encode.go
+++ b/json/encode.go
@@ -592,6 +592,10 @@ func (e encoder) encodeInterface(b []byte, p unsafe.Pointer) ([]byte, error) {
 	return Append(b, *(*interface{})(p), e.flags)
 }
 
+func (e encoder) encodeMaybeEmptyInterface(b []byte, p unsafe.Pointer, t reflect.Type) ([]byte, error) {
+	return Append(b, reflect.NewAt(t, p).Elem().Interface(), e.flags)
+}
+
 func (e encoder) encodeUnsupportedTypeError(b []byte, p unsafe.Pointer, t reflect.Type) ([]byte, error) {
 	return b, &UnsupportedTypeError{Type: t}
 }

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"encoding"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -1474,4 +1475,17 @@ func TestGithubIssue26(t *testing.T) {
 	if err := Unmarshal(data, &value); err != nil {
 		t.Error(err)
 	}
+}
+
+func TestGithubIssue28(t *testing.T) {
+	type A struct {
+		Err error `json:"err"`
+	}
+
+	if b, err := Marshal(&A{Err: errors.New("ABC")}); err != nil {
+		t.Error(err)
+	} else if string(b) != `{"err":{}}` {
+		t.Error(string(b))
+	}
+
 }


### PR DESCRIPTION
Fixes #28 

Go does some magic when converting from non-empty to empty interfaces, the casting of `*(*interface{})(p)` for all interface types was not good enough.

This PR addresses it by falling back to the reflect package for this specific case. I don't anticipate this having an impact on performance, non-empty interface types in JSON are rare because they can't really be unmarshaled, and the use of `reflect.NewAt` and conversion of an interface to `interface{}` doesn't add much overhead.

I've added a test which was reproducing the bug and is now passing with the fix.