### PR TITLE
Add StringifyLargeInt encoder flag

### DIFF
--- a/json/codec.go
+++ b/json/codec.go
@@ -225,6 +225,12 @@ func constructStringDecodeFunc(decode decodeFunc) decodeFunc {
 	}
 }
 
+func constructIntToStringEncodeFunc(encode encodeFunc) encodeFunc {
+	return func(e encoder, b []byte, p unsafe.Pointer) ([]byte, error) {
+		return e.encodeIntToString(b, p, encode)
+	}
+}
+
 func constructStringToIntDecodeFunc(t reflect.Type, decode decodeFunc) decodeFunc {
 	return func(d decoder, b []byte, p unsafe.Pointer) ([]byte, error) {
 		return d.decodeFromStringToInt(b, p, t, decode)
@@ -606,7 +612,7 @@ func appendStructFields(fields []structField, t reflect.Type, offset uintptr, se
 				reflect.Uint16,
 				reflect.Uint32,
 				reflect.Uint64:
-				codec.encode = constructStringEncodeFunc(codec.encode)
+				codec.encode = constructIntToStringEncodeFunc(codec.encode)
 				codec.decode = constructStringToIntDecodeFunc(typ, codec.decode)
 			case reflect.Bool,
 				reflect.Float32,

--- a/json/encode.go
+++ b/json/encode.go
@@ -15,6 +15,31 @@ import (
 
 const hex = "0123456789abcdef"
 
+// jsMaxSafeInt is the maximum safe integer in JavaScript.
+//
+// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
+const jsMaxSafeInt = 1<<53 - 1
+
+func (e encoder) appendInt(b []byte, n int64) []byte {
+	if (e.flags&StringifyLargeInts) != 0 && n > jsMaxSafeInt {
+		b = append(b, '"')
+		b = strconv.AppendInt(b, n, 10)
+		b = append(b, '"')
+		return b
+	}
+	return strconv.AppendInt(b, n, 10)
+}
+
+func (e encoder) appendUint(b []byte, n uint64) []byte {
+	if (e.flags&StringifyLargeInts) != 0 && n > jsMaxSafeInt {
+		b = append(b, '"')
+		b = strconv.AppendUint(b, n, 10)
+		b = append(b, '"')
+		return b
+	}
+	return strconv.AppendUint(b, n, 10)
+}
+
 func (e encoder) encodeNull(b []byte, p unsafe.Pointer) ([]byte, error) {
 	return append(b, "null"...), nil
 }
@@ -27,7 +52,7 @@ func (e encoder) encodeBool(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (e encoder) encodeInt(b []byte, p unsafe.Pointer) ([]byte, error) {
-	return strconv.AppendInt(b, int64(*(*int)(p)), 10), nil
+	return e.appendInt(b, int64(*(*int)(p))), nil
 }
 
 func (e encoder) encodeInt8(b []byte, p unsafe.Pointer) ([]byte, error) {
@@ -43,15 +68,15 @@ func (e encoder) encodeInt32(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (e encoder) encodeInt64(b []byte, p unsafe.Pointer) ([]byte, error) {
-	return strconv.AppendInt(b, *(*int64)(p), 10), nil
+	return e.appendInt(b, *(*int64)(p)), nil
 }
 
 func (e encoder) encodeUint(b []byte, p unsafe.Pointer) ([]byte, error) {
-	return strconv.AppendUint(b, uint64(*(*uint)(p)), 10), nil
+	return e.appendUint(b, uint64(*(*uint)(p))), nil
 }
 
 func (e encoder) encodeUintptr(b []byte, p unsafe.Pointer) ([]byte, error) {
-	return strconv.AppendUint(b, uint64(*(*uintptr)(p)), 10), nil
+	return e.appendUint(b, uint64(*(*uintptr)(p))), nil
 }
 
 func (e encoder) encodeUint8(b []byte, p unsafe.Pointer) ([]byte, error) {
@@ -67,7 +92,7 @@ func (e encoder) encodeUint32(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (e encoder) encodeUint64(b []byte, p unsafe.Pointer) ([]byte, error) {
-	return strconv.AppendUint(b, *(*uint64)(p), 10), nil
+	return e.appendUint(b, *(*uint64)(p)), nil
 }
 
 func (e encoder) encodeFloat32(b []byte, p unsafe.Pointer) ([]byte, error) {

--- a/json/json.go
+++ b/json/json.go
@@ -69,6 +69,10 @@ const (
 	// than 9007199254740991 as a JSON-encoded string. This extra level
 	// of encoding is sometimes used when communicating with JavaScript programs.
 	StringifyLargeInts
+
+	// stringifyInts is an internal flag like StringifyLargeInts, but is used to
+	// always encode integers as a JSON-encoded string.
+	stringifyInts
 )
 
 // ParseFlags is a type used to represent configuration options that can be

--- a/json/json.go
+++ b/json/json.go
@@ -64,6 +64,11 @@ const (
 	// encoding JSON (this matches the behavior of the standard encoding/json
 	// package).
 	SortMapKeys
+
+	// StringifyLargeInts is a formatting flag used to encode integers bigger
+	// than 9007199254740991 as a JSON-encoded string. This extra level
+	// of encoding is sometimes used when communicating with JavaScript programs.
+	StringifyLargeInts
 )
 
 // ParseFlags is a type used to represent configuration options that can be
@@ -420,6 +425,17 @@ func (enc *Encoder) SetSortMapKeys(on bool) {
 		enc.flags |= SortMapKeys
 	} else {
 		enc.flags &= ^SortMapKeys
+	}
+}
+
+// SetSortMapKeys is an extension to the standard encoding/json package which
+// allows the program to toggle encoding integers bigger than 9007199254740991
+// as strings on and off.
+func (enc *Encoder) SetStringifyLargeInts(on bool) {
+	if on {
+		enc.flags |= StringifyLargeInts
+	} else {
+		enc.flags &= ^StringifyLargeInts
 	}
 }
 

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1489,3 +1489,34 @@ func TestGithubIssue28(t *testing.T) {
 	}
 
 }
+
+func TestStringifyLargeInts(t *testing.T) {
+	// From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
+	if jsMaxSafeInt != 9007199254740991 {
+		t.Errorf("got %d, wanted %d", jsMaxSafeInt, 9007199254740991)
+	}
+
+	nn := []interface{}{
+		int(jsMaxSafeInt + 2),
+		uint(jsMaxSafeInt + 2),
+		int64(jsMaxSafeInt + 2),
+		uint64(jsMaxSafeInt + 2),
+	}
+
+	for _, n := range nn {
+		var buf bytes.Buffer
+		enc := NewEncoder(&buf)
+		enc.SetStringifyLargeInts(true)
+
+		err := enc.Encode(n)
+		if err != nil {
+			t.Error(err)
+		}
+
+		got := buf.String()
+		wanted := fmt.Sprintf(`"%d"`+"\n", n)
+		if got != wanted {
+			t.Errorf("got %s, wanted %s", got, wanted)
+		}
+	}
+}


### PR DESCRIPTION
This is another solution for https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER problem which does not require `,string` tag on the field and works with `map[string]interface{}`.