### PR TITLE
Add support for json.Decoder InputOffset()

### DIFF
--- a/json/json.go
+++ b/json/json.go
@@ -234,11 +234,12 @@ func Valid(data []byte) bool {
 
 // Decoder is documented at https://golang.org/pkg/encoding/json/#Decoder
 type Decoder struct {
-	reader io.Reader
-	buffer []byte
-	remain []byte
-	err    error
-	flags  ParseFlags
+	reader      io.Reader
+	buffer      []byte
+	remain      []byte
+	inputOffset int64
+	err         error
+	flags       ParseFlags
 }
 
 // NewDecoder is documented at https://golang.org/pkg/encoding/json/#NewDecoder
@@ -274,7 +275,8 @@ func (dec *Decoder) readValue() (v []byte, err error) {
 		if len(dec.remain) != 0 {
 			v, r, err = parseValue(dec.remain)
 			if err == nil {
-				dec.remain = skipSpaces(r)
+				dec.remain, n = skipSpacesN(r)
+				dec.inputOffset += int64(len(v) + n)
 				return
 			}
 			if len(r) != 0 {
@@ -309,7 +311,9 @@ func (dec *Decoder) readValue() (v []byte, err error) {
 		if n > 0 {
 			dec.buffer = dec.buffer[:len(dec.buffer)+n]
 		}
-		dec.remain, dec.err = skipSpaces(dec.buffer), err
+		dec.remain, n = skipSpacesN(dec.buffer)
+		dec.inputOffset += int64(n)
+		dec.err = err
 	}
 }
 
@@ -346,6 +350,13 @@ func (dec *Decoder) DontMatchCaseInsensitiveStructFields() {
 // ZeroCopy is an extension to the standard encoding/json package which enables
 // all the copy optimizations of the decoder.
 func (dec *Decoder) ZeroCopy() { dec.flags |= ZeroCopy }
+
+// InputOffset returns the input stream byte offset of the current decoder position.
+// The offset gives the location of the end of the most recently returned token
+// and the beginning of the next token.
+func (dec *Decoder) InputOffset() int64 {
+	return dec.inputOffset
+}
 
 // Encoder is documented at https://golang.org/pkg/encoding/json/#Encoder
 type Encoder struct {

--- a/json/parse.go
+++ b/json/parse.go
@@ -25,14 +25,19 @@ const (
 )
 
 func skipSpaces(b []byte) []byte {
+	b, _ = skipSpacesN(b)
+	return b
+}
+
+func skipSpacesN(b []byte) ([]byte, int) {
 	for i := range b {
 		switch b[i] {
 		case sp, ht, nl, cr:
 		default:
-			return b[i:]
+			return b[i:], i
 		}
 	}
-	return nil
+	return nil, 0
 }
 
 // parseInt parses a decimanl representation of an int64 from b.


### PR DESCRIPTION
go version 1.14 adds support for getting the input offset
of a json.Decoder (https://golang.org/pkg/encoding/json/#Decoder.InputOffset)

This commit adds identical functionality to segmentio/encoding

Signed-off-by: Daniel Ferstay <dferstay@splunk.com>