### PR TITLE
1.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/golang:1.13
+      - image: circleci/golang:1.14
     steps:
       - checkout
       - run: go mod download

--- a/json/golang_scanner_test.go
+++ b/json/golang_scanner_test.go
@@ -47,6 +47,7 @@ var examples = []example{
 	{`[1,2,3]`, "[\n\t1,\n\t2,\n\t3\n]"},
 	{`{"x":1}`, "{\n\t\"x\": 1\n}"},
 	{ex1, ex1i},
+	{"{\"\":\"<>&\u2028\u2029\"}", "{\n\t\"\": \"<>&\u2028\u2029\"\n}"}, // See golang.org/issue/34070
 }
 
 var ex1 = `[true,false,null,"x",1,1.5,0,-5e+2]`
@@ -88,8 +89,8 @@ func TestCompactSeparators(t *testing.T) {
 	tests := []struct {
 		in, compact string
 	}{
-		{"{\"\u2028\": 1}", `{"\u2028":1}`},
-		{"{\"\u2029\" :2}", `{"\u2029":2}`},
+		{"{\"\u2028\": 1}", "{\"\u2028\":1}"},
+		{"{\"\u2029\" :2}", "{\"\u2029\":2}"},
 	}
 	for _, tt := range tests {
 		var buf bytes.Buffer

--- a/json/reflect.go
+++ b/json/reflect.go
@@ -1,4 +1,4 @@
-// +build go1.14
+// +build go1.15
 
 package json
 

--- a/json/reflect_optimize.go
+++ b/json/reflect_optimize.go
@@ -1,4 +1,4 @@
-// +build !go1.14
+// +build !go1.15
 
 package json
 


### PR DESCRIPTION
There was a behavior change on `encoding/json` in Go 1.14: https://github.com/golang/go/pull/34804

The `unsafe_NewArray` function is still available in the runtime as well, so enable it on Go 1.14.