### PR TITLE
fix pathological decoder reads

### DIFF
--- a/json/json.go
+++ b/json/json.go
@@ -305,9 +305,12 @@ func (dec *Decoder) readValue() (v []byte, err error) {
 			dec.buffer = buf
 		}
 
-		n, err = dec.reader.Read(dec.buffer[len(dec.buffer):cap(dec.buffer)])
+		n, err = io.ReadFull(dec.reader, dec.buffer[len(dec.buffer):cap(dec.buffer)])
 		if n > 0 {
 			dec.buffer = dec.buffer[:len(dec.buffer)+n]
+		}
+		if err == io.ErrUnexpectedEOF {
+			err = io.EOF
 		}
 		dec.remain, dec.err = skipSpaces(dec.buffer), err
 	}


### PR DESCRIPTION
@alberts reported that he found a case where `segmentio/encoding` was performing ~2x slower than the standard library or json decoders in other languages when decoding from a `gzip.Reader`.

I did a bit of investigation and it turns out `gzip.Reader` will returns at most 32KB by default in calls to `gzip.(*Reader).Read`. The `json.Decoder` was trying to parse the content of its buffer after each read from the underlying stream, which caused really slow buffer growth and many failed attempts at reading partial JSON.

The fix consists in changing from calling `Read` directly to using `io.ReadFull`, which will fill the decoder's buffer until `io.EOF` is reached. In this particular case it reduced 75x the number of times the decoder attempted to parse the content of its buffer.

From the debug logs I added, before the change:
```
...
Read(7797457) => (32768, <nil>) #2303
Read(7764689) => (32768, <nil>) #2304
Read(7731921) => (32768, <nil>) #2305
Read(7699153) => (32768, <nil>) #2306
Read(7666385) => (32768, <nil>) #2307
Read(8387107) => (32768, <nil>) #2308
Read(8374588) => (32768, <nil>) #2309
Read(8363512) => (32768, <nil>) #2310
Read(8382049) => (32768, <nil>) #2311
Read(8379069) => (32768, <nil>) #2312
Read(8346301) => (32768, <nil>) #2313
Read(8365604) => (32768, <nil>) #2314
Read(8365621) => (24570, EOF) #2315
```
then using `io.ReadFull`:
```
Read(32768) => (32768, <nil>) #1
Read(32768) => (32768, <nil>) #2
Read(47948) => (47948, <nil>) #3
Read(65536) => (65536, <nil>) #4
Read(78934) => (78934, <nil>) #5
Read(131072) => (131072, <nil>) #6
Read(255855) => (255855, <nil>) #7
Read(118910) => (118910, <nil>) #8
Read(262144) => (262144, <nil>) #9
Read(385086) => (385086, <nil>) #10
Read(524288) => (524288, <nil>) #11
Read(1024869) => (1024869, <nil>) #12
Read(902466) => (902466, <nil>) #13
Read(882363) => (882363, <nil>) #14
Read(888508) => (888508, <nil>) #15
Read(578943) => (578943, <nil>) #16
Read(734713) => (734713, <nil>) #17
Read(717494) => (717494, <nil>) #18
Read(1048576) => (1048576, <nil>) #19
Read(2097152) => (2097152, <nil>) #20
Read(4194304) => (4194304, <nil>) #21
Read(8350890) => (8350890, <nil>) #22
Read(5432314) => (5432314, <nil>) #23
Read(8386066) => (8386066, <nil>) #24
Read(5070901) => (5070901, <nil>) #25
Read(8024419) => (8024419, <nil>) #26
Read(8382645) => (8382645, <nil>) #27
Read(8387704) => (8387704, <nil>) #28
Read(8283812) => (8283812, <nil>) #29
Read(7676569) => (296898, unexpected EOF) #30
```

Here was the load time before the change:
```
loading state from state.json.gz

real	0m3.359s
user	0m2.873s
sys	0m0.043s
```

Then after the change:
```
loading state from state.json.gz

real	0m0.871s
user	0m0.572s
sys	0m0.039s
```

Then compared to using the standard `encoding/json`:
```
loading state from state.json.gz

real	0m1.761s
user	0m0.942s
sys	0m0.052s
```