### PR TITLE
don't report errors if data was loaded in the buffer

### DIFF
--- a/json/json.go
+++ b/json/json.go
@@ -315,8 +315,10 @@ func (dec *Decoder) readValue() (v []byte, err error) {
 		n, err = io.ReadFull(dec.reader, dec.buffer[len(dec.buffer):cap(dec.buffer)])
 		if n > 0 {
 			dec.buffer = dec.buffer[:len(dec.buffer)+n]
-		}
-		if err == io.ErrUnexpectedEOF {
+			if err != nil {
+				err = nil
+			}
+		} else if err == io.ErrUnexpectedEOF {
 			err = io.EOF
 		}
 		dec.remain, n = skipSpacesN(dec.buffer)


### PR DESCRIPTION
Fix benchmarks that were not running anymore after #35:
```
goos: darwin
goarch: amd64
pkg: github.com/segmentio/encoding/json
BenchmarkCodeDecoder    	--- FAIL: BenchmarkCodeDecoder
    golang_bench_test.go:165: Decode: EOF
BenchmarkUnicodeDecoder 	--- FAIL: BenchmarkUnicodeDecoder
    golang_bench_test.go:182: Decode: EOF
--- FAIL: BenchmarkDecoderStream
    golang_bench_test.go:206: Decode: EOF after 0
FAIL
exit status 1
FAIL	github.com/segmentio/encoding/json	1.257s
```
```
goos: darwin
goarch: amd64
pkg: github.com/segmentio/encoding/json
BenchmarkCodeDecoder    	      94	  12776072 ns/op	 151.88 MB/s	  553867 B/op	   12954 allocs/op
BenchmarkUnicodeDecoder 	 4531942	       273 ns/op	  51.26 MB/s	      16 B/op	       1 allocs/op
BenchmarkDecoderStream  	11054839	       106 ns/op	       8 B/op	       1 allocs/op
PASS
ok  	github.com/segmentio/encoding/json	5.642s
```