### PR TITLE
fix pathological performance issue parsing heavily escaped strings

### DIFF
--- a/json/parse_test.go
+++ b/json/parse_test.go
@@ -133,3 +133,42 @@ func BenchmarkHasFalsePrefix(b *testing.B) {
 		benchmarkHasPrefixResult = hasFalsePrefix(benchmarkHasPrefixString)
 	}
 }
+
+func BenchmarkParseStringEscapeNone(b *testing.B) {
+	var j = []byte(`"` + strings.Repeat(`a`, 1000) + `"`)
+	var s string
+	b.SetBytes(int64(len(j)))
+
+	for i := 0; i < b.N; i++ {
+		if err := Unmarshal(j, &s); err != nil {
+			b.Fatal(err)
+		}
+		s = ""
+	}
+}
+
+func BenchmarkParseStringEscapeOne(b *testing.B) {
+	var j = []byte(`"` + strings.Repeat(`a`, 998) + `\n"`)
+	var s string
+	b.SetBytes(int64(len(j)))
+
+	for i := 0; i < b.N; i++ {
+		if err := Unmarshal(j, &s); err != nil {
+			b.Fatal(err)
+		}
+		s = ""
+	}
+}
+
+func BenchmarkParseStringEscapeAll(b *testing.B) {
+	var j = []byte(`"` + strings.Repeat(`\`, 1000) + `"`)
+	var s string
+	b.SetBytes(int64(len(j)))
+
+	for i := 0; i < b.N; i++ {
+		if err := Unmarshal(j, &s); err != nil {
+			b.Fatal(err)
+		}
+		s = ""
+	}
+}


### PR DESCRIPTION
The code contained a O(N^2) path for strings with large amounts of escaping, this PR addresses it by ensuring at most one pass is done on escaped strings.

```
benchmark                          old ns/op     new ns/op     delta
BenchmarkParseStringEscapeNone     583           571           -2.06%
BenchmarkParseStringEscapeOne      6609          7247          +9.65%
BenchmarkParseStringEscapeAll      82099         6823          -91.69%

benchmark                          old MB/s     new MB/s     speedup
BenchmarkParseStringEscapeNone     1719.37      1753.43      1.02x
BenchmarkParseStringEscapeOne      151.61       138.25       0.91x
BenchmarkParseStringEscapeAll      12.20        146.85       12.04x
```