### PR TITLE
Bug Fix: Remove extra commas from embedded struct field

### DIFF
--- a/json/encode.go
+++ b/json/encode.go
@@ -540,10 +540,6 @@ func (e encoder) encodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 			continue
 		}
 
-		if n != 0 {
-			b = append(b, ',')
-		}
-
 		if (e.flags & EscapeHTML) != 0 {
 			k = f.html
 		} else {
@@ -551,6 +547,11 @@ func (e encoder) encodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 		}
 
 		lengthBeforeKey := len(b)
+
+		if n != 0 {
+			b = append(b, ',')
+		}
+
 		b = append(b, k...)
 		b = append(b, ':')
 

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1536,6 +1536,29 @@ func TestGithubIssue28(t *testing.T) {
 
 }
 
+func TestGithubIssue41(t *testing.T) {
+	expectedString := `{"Zero":0,"Three":3}`
+	type M struct {
+		One int
+		Two int
+	}
+	type N struct {
+		Zero int
+		*M
+		Three int
+	}
+
+	if b, err := Marshal(N{Three: 3}); err != nil {
+		t.Error(err)
+	} else if string(b) != expectedString {
+		t.Error(
+			"got: ", string(b),
+			"expected: ", expectedString,
+		)
+	}
+
+}
+
 func TestSetTrustRawMessage(t *testing.T) {
 	buf := &bytes.Buffer{}
 	enc := NewEncoder(buf)


### PR DESCRIPTION
Upon encoding a struct embedded with an
uninitialized pointer of another struct extra commas
were being generated.

This was primarily because of not rolling back
the comma we add for each field in case of encode failure.
Rearranged the if conditional to mitigate the issue.

Added corresponding unit test as well.
For detailed description of issue refer -https://github.com/segmentio/encoding/issues/41