### PR TITLE
go.mod: bump Go version.  run `go mod tidy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,21 @@ performance library, we also aim for very low development and maintenance overhe
 by implementing APIs that can be used as drop-in replacements for the default
 solutions.
 
+## Requirements and Maintenance Schedule
+
+This package has no dependencies outside of the core runtime of Go.  It
+requires a recent version of Go.
+
+This package follows the same maintenance schedule as the [Go
+project](https://github.com/golang/go/wiki/Go-Release-Cycle#release-maintenance),
+meaning that issues relating to versions of Go which aren't supported by the Go
+team, or versions of this package which are older than 1 year, are unlikely to
+be considered.
+
+Additionally, we have fuzz tests which aren't a runtime required dependency but
+will be pulled in when running `go mod tidy`.  Please don't include these go.mod
+updates in change requests.
+
 ## encoding/json [![GoDoc](https://godoc.org/github.com/segmentio/encoding/json?status.svg)](https://godoc.org/github.com/segmentio/encoding/json)
 
 More details about the implementation of this package can be found [here](json/README.md).

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/segmentio/encoding
 
-go 1.13
+go 1.14


### PR DESCRIPTION
It did update the mod and sum files to include the fuzz corpus package
for the fuzz testing that we do.  It appears that go modules does not
have a concept of test-only dependencies.  Not sure what we want to do
here, since one of the benefits of this package is 0-dependencies
drop-in functional replacement for encoding/json. I could go either way:
just not running go mod tidy on checkin, or requiring it.

cc @achille-roussel 

Fixes #43 