### PR TITLE
Fix truncated unicode string

### DIFF
--- a/json/parse.go
+++ b/json/parse.go
@@ -371,7 +371,7 @@ func parseNumber(b []byte) (v, r []byte, err error) {
 
 func parseUnicode(b []byte) (rune, int, error) {
 	if len(b) < 4 {
-		return 0, 0, syntaxError(b, "unicode code point must have at least 4 characters")
+		return 0, len(b), syntaxError(b, "unicode code point must have at least 4 characters")
 	}
 
 	u, r, err := parseUintHex(b[:4])
@@ -411,7 +411,7 @@ func parseStringFast(b []byte) ([]byte, []byte, bool, error) {
 				case 'u':
 					_, n, err := parseUnicode(b[i+1:])
 					if err != nil {
-						return nil, b, false, err
+						return nil, b[i+1+n:], false, err
 					}
 					i += n
 				default:

--- a/json/parse.go
+++ b/json/parse.go
@@ -376,11 +376,11 @@ func parseUnicode(b []byte) (rune, int, error) {
 
 	u, r, err := parseUintHex(b[:4])
 	if err != nil {
-		return 0, 0, syntaxError(b, "parsing unicode code point: %s", err)
+		return 0, 4, syntaxError(b, "parsing unicode code point: %s", err)
 	}
 
 	if len(r) != 0 {
-		return 0, 0, syntaxError(b, "invalid unicode code point")
+		return 0, 4, syntaxError(b, "invalid unicode code point")
 	}
 
 	return rune(u), 4, nil


### PR DESCRIPTION
**Description**
If a string with unicode characters is truncated, the original byte[] b is returned.
https://github.com/segmentio/encoding/blob/fce24302dbb72e018a3ec81378e67e53bc1d3a7b/json/parse.go#L412-L415

Then in Decoder `readValue()`, the error would be returned instead of doubling the buffer size. https://github.com/segmentio/encoding/blob/fce24302dbb72e018a3ec81378e67e53bc1d3a7b/json/json.go#L287-L292

Typically, when a string is truncated, the returned byte[] has 0 length.
https://github.com/segmentio/encoding/blob/fce24302dbb72e018a3ec81378e67e53bc1d3a7b/json/parse.go#L398-L400

The issue is fixed by returning the the number of bytes consumed in `parseUnicdoe()` for error cases, and shifting the position in `parseStringFast()`.

`parseStringUnquote()` calls `parseUnicdoe()` as well, but the position is not shifted for error cases because the error cases in `parseStringUnquote()` do not need to shift byte[] position (I may be wrong here.).
