### PR TITLE
json: add AppendEscaped function for directly encoding strings

### DIFF
--- a/json/json.go
+++ b/json/json.go
@@ -142,6 +142,15 @@ func Append(b []byte, x interface{}, flags AppendFlags) ([]byte, error) {
 	return b, err
 }
 
+// AppendEscaped appends s to b with the string escaped as a JSON value.
+// This will include the starting and ending quote characters, and the
+// appropriate characters will be escaped correctly for JSON encoding.
+func AppendEscaped(b []byte, s string, flags AppendFlags) []byte {
+	e := encoder{flags: flags}
+	b, _ = e.encodeString(b, unsafe.Pointer(&s))
+	return b
+}
+
 // Compact is documented at https://golang.org/pkg/encoding/json/#Compact
 func Compact(dst *bytes.Buffer, src []byte) error {
 	return json.Compact(dst, src)

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1646,3 +1646,46 @@ func TestSetTrustRawMessage(t *testing.T) {
 		)
 	}
 }
+
+func TestAppendEscaped(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		b := AppendEscaped([]byte{}, `value`, AppendFlags(0))
+		exp := []byte(`"value"`)
+		if bytes.Compare(exp, b) != 0 {
+			t.Error(
+				"unexpected encoding:",
+				"expected", exp,
+				"got", b,
+			)
+		}
+	})
+
+	t.Run("escaped", func(t *testing.T) {
+		b := AppendEscaped([]byte{}, `"escaped"	<value>`, EscapeHTML)
+		exp := []byte(`"\"escaped\"\t\u003cvalue\u003e"`)
+		if bytes.Compare(exp, b) != 0 {
+			t.Error(
+				"unexpected encoding:",
+				"expected", exp,
+				"got", b,
+			)
+		}
+	})
+
+	t.Run("build", func(t *testing.T) {
+		b := []byte{}
+		b = append(b, '{')
+		b = AppendEscaped(b, `key`, EscapeHTML)
+		b = append(b, ':')
+		b = AppendEscaped(b, `"escaped"	<value>`, EscapeHTML)
+		b = append(b, '}')
+		exp := []byte(`{"key":"\"escaped\"\t\u003cvalue\u003e"}`)
+		if bytes.Compare(exp, b) != 0 {
+			t.Error(
+				"unexpected encoding:",
+				"expected", exp,
+				"got", b,
+			)
+		}
+	})
+}


### PR DESCRIPTION
This change exposes an `AppendEscaped` function that directly encodes a string into it's JSON-encoded counterpart by appending it to a `[]byte` buffer. This works similarly to the `Append` function, but it bypasses the type matching and it is does not produce an `error`. For example:

```go
b := json.AppendEscaped([]byte{}, `"escaped"	<value>`, json.EscapeHTML)
println(string(b)) // "\"escaped\"\t\u003cvalue\u003e"
```