### PR TITLE
fix invalid use of unsafe reported by go-safer

### DIFF
--- a/json/codec.go
+++ b/json/codec.go
@@ -1022,13 +1022,18 @@ func uintStringsAreSorted(u0, u1 uint64) bool {
 	return string(strconv.AppendUint(b0[:0], u0, 10)) < string(strconv.AppendUint(b1[:0], u1, 10))
 }
 
-//go:nosplit
 func stringToBytes(s string) []byte {
-	return *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-		Data: ((*reflect.StringHeader)(unsafe.Pointer(&s))).Data,
+	return *(*[]byte)(unsafe.Pointer(&sliceHeader{
+		Data: *(*unsafe.Pointer)(unsafe.Pointer(&s)),
 		Len:  len(s),
 		Cap:  len(s),
 	}))
+}
+
+type sliceHeader struct {
+	Data unsafe.Pointer
+	Len  int
+	Cap  int
 }
 
 var (

--- a/json/string.go
+++ b/json/string.go
@@ -2,7 +2,6 @@ package json
 
 import (
 	"math/bits"
-	"reflect"
 	"unsafe"
 )
 
@@ -63,8 +62,8 @@ func expand(b byte) uint64 {
 }
 
 func stringToUint64(s string) []uint64 {
-	return *(*[]uint64)(unsafe.Pointer(&reflect.SliceHeader{
-		Data: ((*reflect.StringHeader)(unsafe.Pointer(&s))).Data,
+	return *(*[]uint64)(unsafe.Pointer(&sliceHeader{
+		Data: *(*unsafe.Pointer)(unsafe.Pointer(&s)),
 		Len:  len(s) / 8,
 		Cap:  len(s) / 8,
 	}))

--- a/proto/bytes.go
+++ b/proto/bytes.go
@@ -52,11 +52,17 @@ func decodeBytes(b []byte, p unsafe.Pointer, _ flags) (int, error) {
 }
 
 func makeBytes(p unsafe.Pointer, n int) []byte {
-	return *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-		Data: uintptr(p),
+	return *(*[]byte)(unsafe.Pointer(&sliceHeader{
+		Data: p,
 		Len:  n,
 		Cap:  n,
 	}))
+}
+
+type sliceHeader struct {
+	Data unsafe.Pointer
+	Len  int
+	Cap  int
 }
 
 // isZeroBytes is an optimized version of this loop:
@@ -79,8 +85,8 @@ func makeBytes(p unsafe.Pointer, n int) []byte {
 // IsZeroBytes64K  14.8µs ± 3%   1.9µs ± 3%  -87.34%  (p=0.000 n=10+10)
 func isZeroBytes(b []byte) bool {
 	if n := len(b) / 8; n != 0 {
-		if !isZeroUint64(*(*[]uint64)(unsafe.Pointer(&reflect.SliceHeader{
-			Data: uintptr(unsafe.Pointer(&b[0])),
+		if !isZeroUint64(*(*[]uint64)(unsafe.Pointer(&sliceHeader{
+			Data: unsafe.Pointer(&b[0]),
 			Len:  n,
 			Cap:  n,
 		}))) {


### PR DESCRIPTION
Reported by:
```
$ go-safer ./...
/Users/achille.roussel/dev/src/github.com/segmentio/encoding/json/codec.go:1027:36: reflect header composite literal found
/Users/achille.roussel/dev/src/github.com/segmentio/encoding/json/string.go:66:38: reflect header composite literal found
/Users/achille.roussel/dev/src/github.com/segmentio/encoding/proto/bytes.go:55:36: reflect header composite literal found
/Users/achille.roussel/dev/src/github.com/segmentio/encoding/proto/bytes.go:82:49: reflect header composite literal found
```