### PR TITLE
Expose Unescape + AppendUnescape helper functions

### DIFF
--- a/json/json.go
+++ b/json/json.go
@@ -161,22 +161,21 @@ func AppendEscape(b []byte, s string, flags AppendFlags) []byte {
 	return b
 }
 
-// Unescape is a convenience helper to construct an unescaped string from s.
+// Unescape is a convenience helper to unescape a JSON value.
 // For more control over the unescape behavior and
 // to write to a pre-allocated buffer, use AppendUnescape.
-func Unescape(s string) []byte {
+func Unescape(s []byte) []byte {
 	b := make([]byte, 0, len(s))
 	return AppendUnescape(b, s, ParseFlags(0))
 }
 
 // AppendUnescape appends s to b with the string unescaped as a JSON value.
 // This will include the starting and ending quote characters, and the
-// appropriate characters will be escaped correctly for JSON encoding.
-func AppendUnescape(b []byte, s string, flags ParseFlags) []byte {
-	var out string
+// appropriate characters will be escaped correctly as if JSON decoded.
+func AppendUnescape(b []byte, s []byte, flags ParseFlags) []byte {
 	d := decoder{flags: flags}
-	b, _ = d.decodeString([]byte(s), unsafe.Pointer(&out))
-	return append(b, []byte(out)...)
+	b, _ = d.decodeString(s, unsafe.Pointer(&s))
+	return s
 }
 
 // Compact is documented at https://golang.org/pkg/encoding/json/#Compact

--- a/json/json.go
+++ b/json/json.go
@@ -161,6 +161,24 @@ func AppendEscape(b []byte, s string, flags AppendFlags) []byte {
 	return b
 }
 
+// Unescape is a convenience helper to construct an unescaped string from s.
+// For more control over the unescape behavior and
+// to write to a pre-allocated buffer, use AppendUnescape.
+func Unescape(s string) []byte {
+	b := make([]byte, 0, len(s))
+	return AppendUnescape(b, s, ParseFlags(0))
+}
+
+// AppendUnescape appends s to b with the string unescaped as a JSON value.
+// This will include the starting and ending quote characters, and the
+// appropriate characters will be escaped correctly for JSON encoding.
+func AppendUnescape(b []byte, s string, flags ParseFlags) []byte {
+	var out string
+	d := decoder{flags: flags}
+	b, _ = d.decodeString([]byte(s), unsafe.Pointer(&out))
+	return append(b, []byte(out)...)
+}
+
 // Compact is documented at https://golang.org/pkg/encoding/json/#Compact
 func Compact(dst *bytes.Buffer, src []byte) error {
 	return json.Compact(dst, src)

--- a/json/json.go
+++ b/json/json.go
@@ -170,12 +170,14 @@ func Unescape(s []byte) []byte {
 }
 
 // AppendUnescape appends s to b with the string unescaped as a JSON value.
-// This will include the starting and ending quote characters, and the
+// This will remove starting and ending quote characters, and the
 // appropriate characters will be escaped correctly as if JSON decoded.
+// New space will be reallocated if more space is needed.
 func AppendUnescape(b []byte, s []byte, flags ParseFlags) []byte {
 	d := decoder{flags: flags}
-	b, _ = d.decodeString(s, unsafe.Pointer(&s))
-	return s
+	buf := new(string)
+	d.decodeString(s, unsafe.Pointer(buf))
+	return append(b, *buf...)
 }
 
 // Compact is documented at https://golang.org/pkg/encoding/json/#Compact

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1756,3 +1756,24 @@ func TestAppendUnescape(t *testing.T) {
 		}
 	})
 }
+
+func BenchmarkUnescape(b *testing.B) {
+	s := []byte(`"\"escaped\"\t\u003cvalue\u003e"`)
+	out := []byte{}
+	for i := 0; i < b.N; i++ {
+		out = Unescape(s)
+	}
+
+	b.Log(string(out))
+}
+
+func BenchmarkUnmarshalField(b *testing.B) {
+	s := []byte(`"\"escaped\"\t\u003cvalue\u003e"`)
+	var v string
+
+	for i := 0; i < b.N; i++ {
+		json.Unmarshal(s, &v)
+	}
+
+	b.Log(v)
+}

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1718,7 +1718,7 @@ func TestUnescapeString(t *testing.T) {
 
 func TestAppendUnescape(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
-		out := AppendUnescape([]byte{}, `"value"`, ParseFlags(0))
+		out := AppendUnescape([]byte{}, []byte(`"value"`), ParseFlags(0))
 		exp := []byte("value")
 		if bytes.Compare(exp, out) != 0 {
 			t.Error(
@@ -1730,7 +1730,7 @@ func TestAppendUnescape(t *testing.T) {
 	})
 
 	t.Run("escaped", func(t *testing.T) {
-		b := AppendUnescape([]byte{}, `"\"escaped\"\t\u003cvalue\u003e"`, ParseFlags(0))
+		b := AppendUnescape([]byte{}, []byte(`"\"escaped\"\t\u003cvalue\u003e"`), ParseFlags(0))
 		exp := []byte(`"escaped"	<value>`)
 		if bytes.Compare(exp, b) != 0 {
 			t.Error(

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1740,4 +1740,19 @@ func TestAppendUnescape(t *testing.T) {
 			)
 		}
 	})
+
+	t.Run("build", func(t *testing.T) {
+		b := []byte{}
+		b = append(b, []byte(`{"key":`)...)
+		b = AppendUnescape(b, []byte(`"\"escaped\"\t\u003cvalue\u003e"`), ParseFlags(0))
+		b = append(b, '}')
+		exp := []byte(`{"key":"escaped"	<value>}`)
+		if bytes.Compare(exp, b) != 0 {
+			t.Error(
+				"unexpected encoding:",
+				"expected", string(exp),
+				"got", string(b),
+			)
+		}
+	})
 }

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1702,3 +1702,42 @@ func TestAppendEscape(t *testing.T) {
 		}
 	})
 }
+
+func TestUnescapeString(t *testing.T) {
+	b := Escape(`value`)
+	x := []byte(`"value"`)
+
+	if !bytes.Equal(x, b) {
+		t.Error(
+			"unexpected encoding:",
+			"expected", string(x),
+			"got", string(b),
+		)
+	}
+}
+
+func TestAppendUnescape(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		out := AppendUnescape([]byte{}, `"value"`, ParseFlags(0))
+		exp := []byte("value")
+		if bytes.Compare(exp, out) != 0 {
+			t.Error(
+				"unexpected decoding:",
+				"expected", exp,
+				"got", out,
+			)
+		}
+	})
+
+	t.Run("escaped", func(t *testing.T) {
+		b := AppendUnescape([]byte{}, `"\"escaped\"\t\u003cvalue\u003e"`, ParseFlags(0))
+		exp := []byte(`"escaped"	<value>`)
+		if bytes.Compare(exp, b) != 0 {
+			t.Error(
+				"unexpected encoding:",
+				"expected", exp,
+				"got", b,
+			)
+		}
+	})
+}

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1704,12 +1704,12 @@ func TestAppendEscape(t *testing.T) {
 }
 
 func TestUnescapeString(t *testing.T) {
-	b := Escape(`value`)
-	x := []byte(`"value"`)
+	b := Unescape([]byte(`"value"`))
+	x := []byte(`value`)
 
 	if !bytes.Equal(x, b) {
 		t.Error(
-			"unexpected encoding:",
+			"unexpected decoding:",
 			"expected", string(x),
 			"got", string(b),
 		)


### PR DESCRIPTION
Similar to https://github.com/segmentio/encoding/pull/60, this pr introduces and exposes `Unescape()` and `AppendUnescape` helper functions.
These simply mirror and inverse the recently exposed `Escape` and `Unescape` functions.