### PR TITLE
optimize json tokenizer

### DIFF
--- a/json/token_test.go
+++ b/json/token_test.go
@@ -315,6 +315,7 @@ func BenchmarkTokenizer(b *testing.B) {
 			for _, value := range values {
 				b.Run(value.scenario, func(b *testing.B) {
 					bechmark.function(b, value.payload)
+					b.SetBytes(int64(len(value.payload)))
 				})
 			}
 		})


### PR DESCRIPTION
This PR adds a few micro-optimizations to improve throughput of the JSON tokenizer:

```
name                                                 old time/op    new time/op    delta
Tokenizer/github.com/segmentio/encoding/json/null      19.8ns ± 2%    18.5ns ± 5%  -6.76%  (p=0.000 n=10+10)
Tokenizer/github.com/segmentio/encoding/json/true      19.9ns ± 3%    18.8ns ± 2%  -5.44%  (p=0.000 n=10+9)
Tokenizer/github.com/segmentio/encoding/json/false     20.1ns ± 2%    18.7ns ± 2%  -6.80%  (p=0.000 n=9+9)
Tokenizer/github.com/segmentio/encoding/json/number    28.2ns ± 3%    26.5ns ± 2%  -6.13%  (p=0.000 n=10+10)
Tokenizer/github.com/segmentio/encoding/json/string    33.9ns ± 4%    31.8ns ± 0%  -6.15%  (p=0.000 n=10+7)
Tokenizer/github.com/segmentio/encoding/json/object    1.63µs ± 5%    1.51µs ± 3%  -6.93%  (p=0.000 n=10+10)

name                                                 old speed      new speed      delta
Tokenizer/github.com/segmentio/encoding/json/null     202MB/s ± 2%   217MB/s ± 5%  +7.32%  (p=0.000 n=10+10)
Tokenizer/github.com/segmentio/encoding/json/true     201MB/s ± 3%   213MB/s ± 2%  +6.03%  (p=0.000 n=10+10)
Tokenizer/github.com/segmentio/encoding/json/false    248MB/s ± 3%   267MB/s ± 2%  +7.64%  (p=0.000 n=10+9)
Tokenizer/github.com/segmentio/encoding/json/number   390MB/s ± 3%   415MB/s ± 2%  +6.43%  (p=0.000 n=10+10)
Tokenizer/github.com/segmentio/encoding/json/string   354MB/s ± 4%   377MB/s ± 0%  +6.61%  (p=0.000 n=10+7)
Tokenizer/github.com/segmentio/encoding/json/object   421MB/s ± 5%   452MB/s ± 2%  +7.36%  (p=0.000 n=10+10)

name                                                 old alloc/op   new alloc/op   delta
Tokenizer/github.com/segmentio/encoding/json/null       0.00B          0.00B         ~     (all equal)
Tokenizer/github.com/segmentio/encoding/json/true       0.00B          0.00B         ~     (all equal)
Tokenizer/github.com/segmentio/encoding/json/false      0.00B          0.00B         ~     (all equal)
Tokenizer/github.com/segmentio/encoding/json/number     0.00B          0.00B         ~     (all equal)
Tokenizer/github.com/segmentio/encoding/json/string     0.00B          0.00B         ~     (all equal)
Tokenizer/github.com/segmentio/encoding/json/object     0.00B          0.00B         ~     (all equal)

name                                                 old allocs/op  new allocs/op  delta
Tokenizer/github.com/segmentio/encoding/json/null        0.00           0.00         ~     (all equal)
Tokenizer/github.com/segmentio/encoding/json/true        0.00           0.00         ~     (all equal)
Tokenizer/github.com/segmentio/encoding/json/false       0.00           0.00         ~     (all equal)
Tokenizer/github.com/segmentio/encoding/json/number      0.00           0.00         ~     (all equal)
Tokenizer/github.com/segmentio/encoding/json/string      0.00           0.00         ~     (all equal)
Tokenizer/github.com/segmentio/encoding/json/object      0.00           0.00         ~     (all equal)
```
