### PR TITLE
allow json tokenizer to be stack allocated

### DIFF
--- a/json/token.go
+++ b/json/token.go
@@ -183,15 +183,14 @@ skipLoop:
 		case ':':
 			t.isKey = false
 		case ',':
-			stack := t.grabStack()
-			if len(stack.state) == 0 {
+			if t.stack == nil || len(t.stack.state) == 0 {
 				t.Err = syntaxError(t.json, "found unexpected comma")
 				return false
 			}
-			if stack.is(inObject) {
+			if t.stack.is(inObject) {
 				t.isKey = true
 			}
-			stack.state[len(stack.state)-1].len++
+			t.stack.state[len(t.stack.state)-1].len++
 		}
 	}
 
@@ -213,7 +212,10 @@ func (t *Tokenizer) index() int {
 }
 
 func (t *Tokenizer) push(typ scope) {
-	t.grabStack().push(typ)
+	if t.stack == nil {
+		t.stack = acquireStack()
+	}
+	t.stack.push(typ)
 }
 
 func (t *Tokenizer) pop(expect scope) error {
@@ -221,13 +223,6 @@ func (t *Tokenizer) pop(expect scope) error {
 		return syntaxError(t.json, "found unexpected character while tokenizing json input")
 	}
 	return nil
-}
-
-func (t *Tokenizer) grabStack() *stack {
-	if t.stack == nil {
-		t.stack = acquireStack()
-	}
-	return t.stack
 }
 
 // RawValue represents a raw json value, it is intended to carry null, true,


### PR DESCRIPTION
This PR modifies the internal implementation of `json.Tokenizer` to help escape analysis succeed at placing these values on the stack.

The change is to move the stack tracking the position of the tokenizer in nested objects to by explicitly heap allocated and managed by a `sync.Pool`, instead of self-referencing the `json.Tokenizer`'s internal buffer, which required the values to be placed on the heap.

![image](https://user-images.githubusercontent.com/865510/111682174-47631800-87e1-11eb-829a-3aafd945f1ac.png)
