### PR TITLE
Inline skipSpaces

### DIFF
--- a/json/parse.go
+++ b/json/parse.go
@@ -25,7 +25,9 @@ const (
 )
 
 func skipSpaces(b []byte) []byte {
-	b, _ = skipSpacesN(b)
+	if len(b) > 0 && b[0] <= 0x20 {
+		b, _ = skipSpacesN(b)
+	}
 	return b
 }
 


### PR DESCRIPTION
This PR improves the hot `skipSpaces` function. Currently the function is inlined, but it unconditionally calls `skipSpacesN` which can't be inlined because of the for loop.

We can skip the `skipSpacesN` call if the buffer is empty or if we can prove that the first char isn't whitespace. To ensure that we stay under the inlining cost, we only call `skipSpacesN` if `b[0] <= 0x20` (which includes all of the JSON whitespace chars):

```
json/parse.go:34:6: cannot inline skipSpacesN: unhandled op RANGE
json/parse.go:27:6: can inline skipSpaces with cost 76 as: func([]byte) []byte { if len(b) > 0 && b[0] <= 32 { b, _ = skipSpacesN(b) }; return b }
```

This yields a nice improvement to decoding speed:

```
name           old time/op    new time/op    delta
CodeDecoder-4    7.84ms ± 1%    6.77ms ± 0%  -13.67%  (p=0.016 n=5+4)

name           old speed      new speed      delta
CodeDecoder-4   248MB/s ± 1%   287MB/s ± 0%  +15.84%  (p=0.016 n=5+4)

name           old alloc/op   new alloc/op   delta
CodeDecoder-4     723kB ± 0%     676kB ± 0%   -6.44%  (p=0.008 n=5+5)

name           old allocs/op  new allocs/op  delta
CodeDecoder-4     13.2k ± 0%     13.1k ± 0%   -0.43%  (p=0.008 n=5+5)
```