### PR TITLE
Preprocess input before parsing

### DIFF
--- a/json/codec.go
+++ b/json/codec.go
@@ -983,17 +983,6 @@ func syntaxError(b []byte, msg string, args ...interface{}) error {
 	return e
 }
 
-func inputError(b []byte, t reflect.Type, flags ParseFlags) ([]byte, error) {
-	if len(b) == 0 {
-		return nil, unexpectedEOF(b)
-	}
-	_, r, err := parseValue(b, flags)
-	if err != nil {
-		return r, err
-	}
-	return skipSpaces(r), unmarshalTypeError(b, t)
-}
-
 func objectKeyError(b []byte, err error) ([]byte, error) {
 	if len(b) == 0 {
 		return nil, unexpectedEOF(b)

--- a/json/codec.go
+++ b/json/codec.go
@@ -20,7 +20,10 @@ type codec struct {
 }
 
 type encoder struct{ flags AppendFlags }
-type decoder struct{ flags ParseFlags }
+type decoder struct {
+	flags      ParseFlags
+	inputFlags inputFlags
+}
 
 type encodeFunc func(encoder, []byte, unsafe.Pointer) ([]byte, error)
 type decodeFunc func(decoder, []byte, unsafe.Pointer) ([]byte, error)
@@ -983,11 +986,11 @@ func syntaxError(b []byte, msg string, args ...interface{}) error {
 	return e
 }
 
-func inputError(b []byte, t reflect.Type) ([]byte, error) {
+func inputError(b []byte, t reflect.Type, flags inputFlags) ([]byte, error) {
 	if len(b) == 0 {
 		return nil, unexpectedEOF(b)
 	}
-	_, r, err := parseValue(b)
+	_, r, err := parseValue(b, flags)
 	if err != nil {
 		return r, err
 	}

--- a/json/codec.go
+++ b/json/codec.go
@@ -20,10 +20,7 @@ type codec struct {
 }
 
 type encoder struct{ flags AppendFlags }
-type decoder struct {
-	flags      ParseFlags
-	inputFlags inputFlags
-}
+type decoder struct{ flags ParseFlags }
 
 type encodeFunc func(encoder, []byte, unsafe.Pointer) ([]byte, error)
 type decodeFunc func(decoder, []byte, unsafe.Pointer) ([]byte, error)
@@ -986,7 +983,7 @@ func syntaxError(b []byte, msg string, args ...interface{}) error {
 	return e
 }
 
-func inputError(b []byte, t reflect.Type, flags inputFlags) ([]byte, error) {
+func inputError(b []byte, t reflect.Type, flags ParseFlags) ([]byte, error) {
 	if len(b) == 0 {
 		return nil, unexpectedEOF(b)
 	}

--- a/json/decode.go
+++ b/json/decode.go
@@ -17,7 +17,7 @@ func (d decoder) decodeNull(b []byte, p unsafe.Pointer) ([]byte, error) {
 	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
-	return inputError(b, nullType, d.inputFlags)
+	return inputError(b, nullType, d.flags)
 }
 
 func (d decoder) decodeBool(b []byte, p unsafe.Pointer) ([]byte, error) {
@@ -34,7 +34,7 @@ func (d decoder) decodeBool(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 
 	default:
-		return inputError(b, boolType, d.inputFlags)
+		return inputError(b, boolType, d.flags)
 	}
 }
 
@@ -43,7 +43,7 @@ func (d decoder) decodeInt(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseInt(b, intType, d.inputFlags)
+	v, r, err := parseInt(b, intType, d.flags)
 	if err != nil {
 		return r, err
 	}
@@ -57,7 +57,7 @@ func (d decoder) decodeInt8(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseInt(b, int8Type, d.inputFlags)
+	v, r, err := parseInt(b, int8Type, d.flags)
 	if err != nil {
 		return r, err
 	}
@@ -75,7 +75,7 @@ func (d decoder) decodeInt16(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseInt(b, int16Type, d.inputFlags)
+	v, r, err := parseInt(b, int16Type, d.flags)
 	if err != nil {
 		return r, err
 	}
@@ -93,7 +93,7 @@ func (d decoder) decodeInt32(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseInt(b, int32Type, d.inputFlags)
+	v, r, err := parseInt(b, int32Type, d.flags)
 	if err != nil {
 		return r, err
 	}
@@ -111,7 +111,7 @@ func (d decoder) decodeInt64(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseInt(b, int64Type, d.inputFlags)
+	v, r, err := parseInt(b, int64Type, d.flags)
 	if err != nil {
 		return r, err
 	}
@@ -125,7 +125,7 @@ func (d decoder) decodeUint(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseUint(b, uintType, d.inputFlags)
+	v, r, err := parseUint(b, uintType, d.flags)
 	if err != nil {
 		return r, err
 	}
@@ -139,7 +139,7 @@ func (d decoder) decodeUintptr(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseUint(b, uintptrType, d.inputFlags)
+	v, r, err := parseUint(b, uintptrType, d.flags)
 	if err != nil {
 		return r, err
 	}
@@ -153,7 +153,7 @@ func (d decoder) decodeUint8(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseUint(b, uint8Type, d.inputFlags)
+	v, r, err := parseUint(b, uint8Type, d.flags)
 	if err != nil {
 		return r, err
 	}
@@ -171,7 +171,7 @@ func (d decoder) decodeUint16(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseUint(b, uint16Type, d.inputFlags)
+	v, r, err := parseUint(b, uint16Type, d.flags)
 	if err != nil {
 		return r, err
 	}
@@ -189,7 +189,7 @@ func (d decoder) decodeUint32(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseUint(b, uint32Type, d.inputFlags)
+	v, r, err := parseUint(b, uint32Type, d.flags)
 	if err != nil {
 		return r, err
 	}
@@ -207,7 +207,7 @@ func (d decoder) decodeUint64(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseUint(b, uint64Type, d.inputFlags)
+	v, r, err := parseUint(b, uint64Type, d.flags)
 	if err != nil {
 		return r, err
 	}
@@ -223,12 +223,12 @@ func (d decoder) decodeFloat32(b []byte, p unsafe.Pointer) ([]byte, error) {
 
 	v, r, err := parseNumber(b)
 	if err != nil {
-		return inputError(b, float32Type, d.inputFlags)
+		return inputError(b, float32Type, d.flags)
 	}
 
 	f, err := strconv.ParseFloat(*(*string)(unsafe.Pointer(&v)), 32)
 	if err != nil {
-		return inputError(b, float32Type, d.inputFlags)
+		return inputError(b, float32Type, d.flags)
 	}
 
 	*(*float32)(p) = float32(f)
@@ -242,12 +242,12 @@ func (d decoder) decodeFloat64(b []byte, p unsafe.Pointer) ([]byte, error) {
 
 	v, r, err := parseNumber(b)
 	if err != nil {
-		return inputError(b, float64Type, d.inputFlags)
+		return inputError(b, float64Type, d.flags)
 	}
 
 	f, err := strconv.ParseFloat(*(*string)(unsafe.Pointer(&v)), 64)
 	if err != nil {
-		return inputError(b, float64Type, d.inputFlags)
+		return inputError(b, float64Type, d.flags)
 	}
 
 	*(*float64)(p) = f
@@ -261,7 +261,7 @@ func (d decoder) decodeNumber(b []byte, p unsafe.Pointer) ([]byte, error) {
 
 	v, r, err := parseNumber(b)
 	if err != nil {
-		return inputError(b, numberType, d.inputFlags)
+		return inputError(b, numberType, d.flags)
 	}
 
 	if (d.flags & DontCopyNumber) != 0 {
@@ -278,10 +278,10 @@ func (d decoder) decodeString(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	s, r, new, err := parseStringUnquote(b, nil, d.inputFlags)
+	s, r, new, err := parseStringUnquote(b, nil, d.flags)
 	if err != nil {
 		if len(b) == 0 || b[0] != '"' {
-			return inputError(b, stringType, d.inputFlags)
+			return inputError(b, stringType, d.flags)
 		}
 		return r, err
 	}
@@ -300,9 +300,9 @@ func (d decoder) decodeFromString(b []byte, p unsafe.Pointer, decode decodeFunc)
 		return decode(d, b, p)
 	}
 
-	v, b, _, err := parseStringUnquote(b, nil, d.inputFlags)
+	v, b, _, err := parseStringUnquote(b, nil, d.flags)
 	if err != nil {
-		return inputError(v, stringType, d.inputFlags)
+		return inputError(v, stringType, d.flags)
 	}
 
 	if v, err = decode(d, v, p); err != nil {
@@ -349,9 +349,9 @@ func (d decoder) decodeFromStringToInt(b []byte, p unsafe.Pointer, t reflect.Typ
 		return b, fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal \"\" into int")
 	}
 
-	v, b, _, err := parseStringUnquote(b, nil, d.inputFlags)
+	v, b, _, err := parseStringUnquote(b, nil, d.flags)
 	if err != nil {
-		return inputError(v, t, d.inputFlags)
+		return inputError(v, t, d.flags)
 	}
 
 	if hasLeadingZeroes(v) {
@@ -387,7 +387,7 @@ func (d decoder) decodeFromStringToInt(b []byte, p unsafe.Pointer, t reflect.Typ
 		if _, _, err := parseNumber(v); err != nil {
 			// When the input value valid JSON we mirror the behavior of the
 			// encoding/json package and return a generic error.
-			if _, _, err := parseValue(v, d.inputFlags); err == nil {
+			if _, _, err := parseValue(v, d.flags); err == nil {
 				return b, fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal %q into int", prefix(v))
 			}
 		}
@@ -406,7 +406,7 @@ func (d decoder) decodeBytes(b []byte, p unsafe.Pointer) ([]byte, error) {
 	}
 
 	if len(b) < 2 {
-		return inputError(b, bytesType, d.inputFlags)
+		return inputError(b, bytesType, d.flags)
 	}
 
 	if b[0] != '"' {
@@ -414,14 +414,14 @@ func (d decoder) decodeBytes(b []byte, p unsafe.Pointer) ([]byte, error) {
 		if len(b) > 0 && b[0] == '[' {
 			return d.decodeSlice(b, p, 1, bytesType, decoder.decodeUint8)
 		}
-		return inputError(b, bytesType, d.inputFlags)
+		return inputError(b, bytesType, d.flags)
 	}
 
 	// The input string contains escaped sequences, we need to parse it before
 	// decoding it to match the encoding/json package behvaior.
-	src, r, _, err := parseStringUnquote(b, nil, d.inputFlags)
+	src, r, _, err := parseStringUnquote(b, nil, d.flags)
 	if err != nil {
-		return inputError(b, bytesType, d.inputFlags)
+		return inputError(b, bytesType, d.flags)
 	}
 
 	dst := make([]byte, base64.StdEncoding.DecodedLen(len(src)))
@@ -445,9 +445,9 @@ func (d decoder) decodeDuration(b []byte, p unsafe.Pointer) ([]byte, error) {
 	// flexible on how durations are formatted, but for the time being, it's
 	// been punted to go2 at the earliest: https://github.com/golang/go/issues/4712
 	if len(b) > 0 && b[0] != '"' {
-		v, r, err := parseInt(b, durationType, d.inputFlags)
+		v, r, err := parseInt(b, durationType, d.flags)
 		if err != nil {
-			return inputError(b, int32Type, d.inputFlags)
+			return inputError(b, int32Type, d.flags)
 		}
 
 		if v < math.MinInt64 || v > math.MaxInt64 {
@@ -459,19 +459,19 @@ func (d decoder) decodeDuration(b []byte, p unsafe.Pointer) ([]byte, error) {
 	}
 
 	if len(b) < 2 || b[0] != '"' {
-		return inputError(b, durationType, d.inputFlags)
+		return inputError(b, durationType, d.flags)
 	}
 
 	i := bytes.IndexByte(b[1:], '"') + 1
 	if i <= 0 {
-		return inputError(b, durationType, d.inputFlags)
+		return inputError(b, durationType, d.flags)
 	}
 
 	s := b[1:i] // trim quotes
 
 	v, err := time.ParseDuration(*(*string)(unsafe.Pointer(&s)))
 	if err != nil {
-		return inputError(b, durationType, d.inputFlags)
+		return inputError(b, durationType, d.flags)
 	}
 
 	*(*time.Duration)(p) = v
@@ -484,19 +484,19 @@ func (d decoder) decodeTime(b []byte, p unsafe.Pointer) ([]byte, error) {
 	}
 
 	if len(b) < 2 || b[0] != '"' {
-		return inputError(b, timeType, d.inputFlags)
+		return inputError(b, timeType, d.flags)
 	}
 
 	i := bytes.IndexByte(b[1:], '"') + 1
 	if i <= 0 {
-		return inputError(b, timeType, d.inputFlags)
+		return inputError(b, timeType, d.flags)
 	}
 
 	s := b[1:i] // trim quotes
 
 	v, err := time.Parse(time.RFC3339Nano, *(*string)(unsafe.Pointer(&s)))
 	if err != nil {
-		return inputError(b, timeType, d.inputFlags)
+		return inputError(b, timeType, d.flags)
 	}
 
 	*(*time.Time)(p) = v
@@ -509,7 +509,7 @@ func (d decoder) decodeArray(b []byte, p unsafe.Pointer, n int, size uintptr, t 
 	}
 
 	if len(b) < 2 || b[0] != '[' {
-		return inputError(b, t, d.inputFlags)
+		return inputError(b, t, d.flags)
 	}
 	b = b[1:]
 
@@ -557,7 +557,7 @@ func (d decoder) decodeArray(b []byte, p unsafe.Pointer, n int, size uintptr, t 
 			return b[1:], nil
 		}
 
-		_, b, err = parseValue(b, d.inputFlags)
+		_, b, err = parseValue(b, d.flags)
 		if err != nil {
 			return b, err
 		}
@@ -576,7 +576,7 @@ func (d decoder) decodeSlice(b []byte, p unsafe.Pointer, size uintptr, t reflect
 	}
 
 	if len(b) < 2 {
-		return inputError(b, t, d.inputFlags)
+		return inputError(b, t, d.flags)
 	}
 
 	if b[0] != '[' {
@@ -586,7 +586,7 @@ func (d decoder) decodeSlice(b []byte, p unsafe.Pointer, size uintptr, t reflect
 		if t.Elem().Kind() == reflect.Uint8 {
 			return d.decodeBytes(b, p)
 		}
-		return inputError(b, t, d.inputFlags)
+		return inputError(b, t, d.flags)
 	}
 
 	input := b
@@ -630,7 +630,7 @@ func (d decoder) decodeSlice(b []byte, p unsafe.Pointer, size uintptr, t reflect
 
 		b, err = decode(d, b, unsafe.Pointer(uintptr(s.data)+(uintptr(s.len)*size)))
 		if err != nil {
-			if _, r, err := parseValue(input, d.inputFlags); err != nil {
+			if _, r, err := parseValue(input, d.flags); err != nil {
 				return r, err
 			} else {
 				b = r
@@ -653,7 +653,7 @@ func (d decoder) decodeMap(b []byte, p unsafe.Pointer, t, kt, vt reflect.Type, k
 	}
 
 	if len(b) < 2 || b[0] != '{' {
-		return inputError(b, t, d.inputFlags)
+		return inputError(b, t, d.flags)
 	}
 	i := 0
 	m := reflect.NewAt(t, p).Elem()
@@ -709,7 +709,7 @@ func (d decoder) decodeMap(b []byte, p unsafe.Pointer, t, kt, vt reflect.Type, k
 		b = skipSpaces(b[1:])
 
 		if b, err = decodeValue(d, b, vptr); err != nil {
-			if _, r, err := parseValue(input, d.inputFlags); err != nil {
+			if _, r, err := parseValue(input, d.flags); err != nil {
 				return r, err
 			} else {
 				b = r
@@ -733,7 +733,7 @@ func (d decoder) decodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, e
 	}
 
 	if len(b) < 2 || b[0] != '{' {
-		return inputError(b, mapStringInterfaceType, d.inputFlags)
+		return inputError(b, mapStringInterfaceType, d.flags)
 	}
 
 	i := 0
@@ -790,7 +790,7 @@ func (d decoder) decodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, e
 
 		b, err = d.decodeInterface(b, unsafe.Pointer(&val))
 		if err != nil {
-			if _, r, err := parseValue(input, d.inputFlags); err != nil {
+			if _, r, err := parseValue(input, d.flags); err != nil {
 				return r, err
 			} else {
 				b = r
@@ -814,7 +814,7 @@ func (d decoder) decodeMapStringRawMessage(b []byte, p unsafe.Pointer) ([]byte, 
 	}
 
 	if len(b) < 2 || b[0] != '{' {
-		return inputError(b, mapStringRawMessageType, d.inputFlags)
+		return inputError(b, mapStringRawMessageType, d.flags)
 	}
 
 	i := 0
@@ -871,7 +871,7 @@ func (d decoder) decodeMapStringRawMessage(b []byte, p unsafe.Pointer) ([]byte, 
 
 		b, err = d.decodeRawMessage(b, unsafe.Pointer(&val))
 		if err != nil {
-			if _, r, err := parseValue(input, d.inputFlags); err != nil {
+			if _, r, err := parseValue(input, d.flags); err != nil {
 				return r, err
 			} else {
 				b = r
@@ -895,7 +895,7 @@ func (d decoder) decodeMapStringString(b []byte, p unsafe.Pointer) ([]byte, erro
 	}
 
 	if len(b) < 2 || b[0] != '{' {
-		return inputError(b, mapStringStringType, d.inputFlags)
+		return inputError(b, mapStringStringType, d.flags)
 	}
 
 	i := 0
@@ -952,7 +952,7 @@ func (d decoder) decodeMapStringString(b []byte, p unsafe.Pointer) ([]byte, erro
 
 		b, err = d.decodeString(b, unsafe.Pointer(&val))
 		if err != nil {
-			if _, r, err := parseValue(input, d.inputFlags); err != nil {
+			if _, r, err := parseValue(input, d.flags); err != nil {
 				return r, err
 			} else {
 				b = r
@@ -976,7 +976,7 @@ func (d decoder) decodeMapStringStringSlice(b []byte, p unsafe.Pointer) ([]byte,
 	}
 
 	if len(b) < 2 || b[0] != '{' {
-		return inputError(b, mapStringStringSliceType, d.inputFlags)
+		return inputError(b, mapStringStringSliceType, d.flags)
 	}
 
 	i := 0
@@ -1034,7 +1034,7 @@ func (d decoder) decodeMapStringStringSlice(b []byte, p unsafe.Pointer) ([]byte,
 
 		b, err = d.decodeSlice(b, unsafe.Pointer(&buf), stringSize, sliceStringType, decoder.decodeString)
 		if err != nil {
-			if _, r, err := parseValue(input, d.inputFlags); err != nil {
+			if _, r, err := parseValue(input, d.flags); err != nil {
 				return r, err
 			} else {
 				b = r
@@ -1061,7 +1061,7 @@ func (d decoder) decodeMapStringBool(b []byte, p unsafe.Pointer) ([]byte, error)
 	}
 
 	if len(b) < 2 || b[0] != '{' {
-		return inputError(b, mapStringBoolType, d.inputFlags)
+		return inputError(b, mapStringBoolType, d.flags)
 	}
 
 	i := 0
@@ -1118,7 +1118,7 @@ func (d decoder) decodeMapStringBool(b []byte, p unsafe.Pointer) ([]byte, error)
 
 		b, err = d.decodeBool(b, unsafe.Pointer(&val))
 		if err != nil {
-			if _, r, err := parseValue(input, d.inputFlags); err != nil {
+			if _, r, err := parseValue(input, d.flags); err != nil {
 				return r, err
 			} else {
 				b = r
@@ -1141,7 +1141,7 @@ func (d decoder) decodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 	}
 
 	if len(b) < 2 || b[0] != '{' {
-		return inputError(b, st.typ, d.inputFlags)
+		return inputError(b, st.typ, d.flags)
 	}
 
 	var err error
@@ -1176,7 +1176,7 @@ func (d decoder) decodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 			return b, syntaxError(b, "cannot decode object key string from 'null' value")
 		}
 
-		k, b, _, err = parseStringUnquote(b, nil, d.inputFlags)
+		k, b, _, err = parseStringUnquote(b, nil, d.flags)
 		if err != nil {
 			return objectKeyError(b, err)
 		}
@@ -1201,14 +1201,14 @@ func (d decoder) decodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 			if (d.flags & DisallowUnknownFields) != 0 {
 				return b, fmt.Errorf("json: unknown field %q", k)
 			}
-			if _, b, err = parseValue(b, d.inputFlags); err != nil {
+			if _, b, err = parseValue(b, d.flags); err != nil {
 				return b, err
 			}
 			continue
 		}
 
 		if b, err = f.codec.decode(d, b, unsafe.Pointer(uintptr(p)+f.offset)); err != nil {
-			if _, r, err := parseValue(input, d.inputFlags); err != nil {
+			if _, r, err := parseValue(input, d.flags); err != nil {
 				return r, err
 			} else {
 				b = r
@@ -1277,7 +1277,7 @@ func (d decoder) decodeInterface(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b, err
 	}
 
-	v, b, err := parseValue(b, d.inputFlags)
+	v, b, err := parseValue(b, d.flags)
 	if err != nil {
 		return b, err
 	}
@@ -1352,7 +1352,7 @@ func (d decoder) decodeMaybeEmptyInterface(b []byte, p unsafe.Pointer, t reflect
 }
 
 func (d decoder) decodeUnmarshalTypeError(b []byte, p unsafe.Pointer, t reflect.Type) ([]byte, error) {
-	v, b, err := parseValue(b, d.inputFlags)
+	v, b, err := parseValue(b, d.flags)
 	if err != nil {
 		return b, err
 	}
@@ -1363,9 +1363,9 @@ func (d decoder) decodeUnmarshalTypeError(b []byte, p unsafe.Pointer, t reflect.
 }
 
 func (d decoder) decodeRawMessage(b []byte, p unsafe.Pointer) ([]byte, error) {
-	v, r, err := parseValue(b, d.inputFlags)
+	v, r, err := parseValue(b, d.flags)
 	if err != nil {
-		return inputError(b, rawMessageType, d.inputFlags)
+		return inputError(b, rawMessageType, d.flags)
 	}
 
 	if (d.flags & DontCopyRawMessage) == 0 {
@@ -1377,7 +1377,7 @@ func (d decoder) decodeRawMessage(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeJSONUnmarshaler(b []byte, p unsafe.Pointer, t reflect.Type, pointer bool) ([]byte, error) {
-	v, b, err := parseValue(b, d.inputFlags)
+	v, b, err := parseValue(b, d.flags)
 	if err != nil {
 		return b, err
 	}
@@ -1397,12 +1397,12 @@ func (d decoder) decodeJSONUnmarshaler(b []byte, p unsafe.Pointer, t reflect.Typ
 func (d decoder) decodeTextUnmarshaler(b []byte, p unsafe.Pointer, t reflect.Type, pointer bool) ([]byte, error) {
 	var value string
 
-	v, b, err := parseValue(b, d.inputFlags)
+	v, b, err := parseValue(b, d.flags)
 	if err != nil {
 		return b, err
 	}
 	if len(v) == 0 {
-		return inputError(v, t, d.inputFlags)
+		return inputError(v, t, d.flags)
 	}
 
 	switch v[0] {
@@ -1410,7 +1410,7 @@ func (d decoder) decodeTextUnmarshaler(b []byte, p unsafe.Pointer, t reflect.Typ
 		_, _, err := parseNull(v)
 		return b, err
 	case '"':
-		s, _, _, err := parseStringUnquote(v, nil, d.inputFlags)
+		s, _, _, err := parseStringUnquote(v, nil, d.flags)
 		if err != nil {
 			return b, err
 		}

--- a/json/decode.go
+++ b/json/decode.go
@@ -43,7 +43,7 @@ func (d decoder) decodeInt(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseInt(b, intType, d.flags)
+	v, r, err := d.parseInt(b, intType)
 	if err != nil {
 		return r, err
 	}
@@ -57,7 +57,7 @@ func (d decoder) decodeInt8(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseInt(b, int8Type, d.flags)
+	v, r, err := d.parseInt(b, int8Type)
 	if err != nil {
 		return r, err
 	}
@@ -75,7 +75,7 @@ func (d decoder) decodeInt16(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseInt(b, int16Type, d.flags)
+	v, r, err := d.parseInt(b, int16Type)
 	if err != nil {
 		return r, err
 	}
@@ -93,7 +93,7 @@ func (d decoder) decodeInt32(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseInt(b, int32Type, d.flags)
+	v, r, err := d.parseInt(b, int32Type)
 	if err != nil {
 		return r, err
 	}
@@ -111,7 +111,7 @@ func (d decoder) decodeInt64(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseInt(b, int64Type, d.flags)
+	v, r, err := d.parseInt(b, int64Type)
 	if err != nil {
 		return r, err
 	}
@@ -125,7 +125,7 @@ func (d decoder) decodeUint(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseUint(b, uintType, d.flags)
+	v, r, err := d.parseUint(b, uintType)
 	if err != nil {
 		return r, err
 	}
@@ -139,7 +139,7 @@ func (d decoder) decodeUintptr(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseUint(b, uintptrType, d.flags)
+	v, r, err := d.parseUint(b, uintptrType)
 	if err != nil {
 		return r, err
 	}
@@ -153,7 +153,7 @@ func (d decoder) decodeUint8(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseUint(b, uint8Type, d.flags)
+	v, r, err := d.parseUint(b, uint8Type)
 	if err != nil {
 		return r, err
 	}
@@ -171,7 +171,7 @@ func (d decoder) decodeUint16(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseUint(b, uint16Type, d.flags)
+	v, r, err := d.parseUint(b, uint16Type)
 	if err != nil {
 		return r, err
 	}
@@ -189,7 +189,7 @@ func (d decoder) decodeUint32(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseUint(b, uint32Type, d.flags)
+	v, r, err := d.parseUint(b, uint32Type)
 	if err != nil {
 		return r, err
 	}
@@ -207,7 +207,7 @@ func (d decoder) decodeUint64(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseUint(b, uint64Type, d.flags)
+	v, r, err := d.parseUint(b, uint64Type)
 	if err != nil {
 		return r, err
 	}
@@ -221,7 +221,7 @@ func (d decoder) decodeFloat32(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseNumber(b)
+	v, r, err := d.parseNumber(b)
 	if err != nil {
 		return d.inputError(b, float32Type)
 	}
@@ -240,7 +240,7 @@ func (d decoder) decodeFloat64(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseNumber(b)
+	v, r, err := d.parseNumber(b)
 	if err != nil {
 		return d.inputError(b, float64Type)
 	}
@@ -259,7 +259,7 @@ func (d decoder) decodeNumber(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseNumber(b)
+	v, r, err := d.parseNumber(b)
 	if err != nil {
 		return d.inputError(b, numberType)
 	}
@@ -278,7 +278,7 @@ func (d decoder) decodeString(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	s, r, new, err := parseStringUnquote(b, nil, d.flags)
+	s, r, new, err := d.parseStringUnquote(b, nil)
 	if err != nil {
 		if len(b) == 0 || b[0] != '"' {
 			return d.inputError(b, stringType)
@@ -300,7 +300,7 @@ func (d decoder) decodeFromString(b []byte, p unsafe.Pointer, decode decodeFunc)
 		return decode(d, b, p)
 	}
 
-	v, b, _, err := parseStringUnquote(b, nil, d.flags)
+	v, b, _, err := d.parseStringUnquote(b, nil)
 	if err != nil {
 		return d.inputError(v, stringType)
 	}
@@ -322,7 +322,7 @@ func (d decoder) decodeFromStringToInt(b []byte, p unsafe.Pointer, t reflect.Typ
 	}
 
 	if len(b) > 0 && b[0] != '"' {
-		v, r, err := parseNumber(b)
+		v, r, err := d.parseNumber(b)
 		if err == nil {
 			// The encoding/json package will return a *json.UnmarshalTypeError if
 			// the input was a floating point number representation, even tho a
@@ -349,7 +349,7 @@ func (d decoder) decodeFromStringToInt(b []byte, p unsafe.Pointer, t reflect.Typ
 		return b, fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal \"\" into int")
 	}
 
-	v, b, _, err := parseStringUnquote(b, nil, d.flags)
+	v, b, _, err := d.parseStringUnquote(b, nil)
 	if err != nil {
 		return d.inputError(v, t)
 	}
@@ -384,10 +384,10 @@ func (d decoder) decodeFromStringToInt(b []byte, p unsafe.Pointer, t reflect.Typ
 		}
 		// When the input value was a valid number representation we retain the
 		// error returned by the decoder.
-		if _, _, err := parseNumber(v); err != nil {
+		if _, _, err := d.parseNumber(v); err != nil {
 			// When the input value valid JSON we mirror the behavior of the
 			// encoding/json package and return a generic error.
-			if _, _, err := parseValue(v, d.flags); err == nil {
+			if _, _, err := d.parseValue(v); err == nil {
 				return b, fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal %q into int", prefix(v))
 			}
 		}
@@ -419,7 +419,7 @@ func (d decoder) decodeBytes(b []byte, p unsafe.Pointer) ([]byte, error) {
 
 	// The input string contains escaped sequences, we need to parse it before
 	// decoding it to match the encoding/json package behvaior.
-	src, r, _, err := parseStringUnquote(b, nil, d.flags)
+	src, r, _, err := d.parseStringUnquote(b, nil)
 	if err != nil {
 		return d.inputError(b, bytesType)
 	}
@@ -445,7 +445,7 @@ func (d decoder) decodeDuration(b []byte, p unsafe.Pointer) ([]byte, error) {
 	// flexible on how durations are formatted, but for the time being, it's
 	// been punted to go2 at the earliest: https://github.com/golang/go/issues/4712
 	if len(b) > 0 && b[0] != '"' {
-		v, r, err := parseInt(b, durationType, d.flags)
+		v, r, err := d.parseInt(b, durationType)
 		if err != nil {
 			return d.inputError(b, int32Type)
 		}
@@ -557,7 +557,7 @@ func (d decoder) decodeArray(b []byte, p unsafe.Pointer, n int, size uintptr, t 
 			return b[1:], nil
 		}
 
-		_, b, err = parseValue(b, d.flags)
+		_, b, err = d.parseValue(b)
 		if err != nil {
 			return b, err
 		}
@@ -630,7 +630,7 @@ func (d decoder) decodeSlice(b []byte, p unsafe.Pointer, size uintptr, t reflect
 
 		b, err = decode(d, b, unsafe.Pointer(uintptr(s.data)+(uintptr(s.len)*size)))
 		if err != nil {
-			if _, r, err := parseValue(input, d.flags); err != nil {
+			if _, r, err := d.parseValue(input); err != nil {
 				return r, err
 			} else {
 				b = r
@@ -709,7 +709,7 @@ func (d decoder) decodeMap(b []byte, p unsafe.Pointer, t, kt, vt reflect.Type, k
 		b = skipSpaces(b[1:])
 
 		if b, err = decodeValue(d, b, vptr); err != nil {
-			if _, r, err := parseValue(input, d.flags); err != nil {
+			if _, r, err := d.parseValue(input); err != nil {
 				return r, err
 			} else {
 				b = r
@@ -790,7 +790,7 @@ func (d decoder) decodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, e
 
 		b, err = d.decodeInterface(b, unsafe.Pointer(&val))
 		if err != nil {
-			if _, r, err := parseValue(input, d.flags); err != nil {
+			if _, r, err := d.parseValue(input); err != nil {
 				return r, err
 			} else {
 				b = r
@@ -871,7 +871,7 @@ func (d decoder) decodeMapStringRawMessage(b []byte, p unsafe.Pointer) ([]byte, 
 
 		b, err = d.decodeRawMessage(b, unsafe.Pointer(&val))
 		if err != nil {
-			if _, r, err := parseValue(input, d.flags); err != nil {
+			if _, r, err := d.parseValue(input); err != nil {
 				return r, err
 			} else {
 				b = r
@@ -952,7 +952,7 @@ func (d decoder) decodeMapStringString(b []byte, p unsafe.Pointer) ([]byte, erro
 
 		b, err = d.decodeString(b, unsafe.Pointer(&val))
 		if err != nil {
-			if _, r, err := parseValue(input, d.flags); err != nil {
+			if _, r, err := d.parseValue(input); err != nil {
 				return r, err
 			} else {
 				b = r
@@ -1034,7 +1034,7 @@ func (d decoder) decodeMapStringStringSlice(b []byte, p unsafe.Pointer) ([]byte,
 
 		b, err = d.decodeSlice(b, unsafe.Pointer(&buf), stringSize, sliceStringType, decoder.decodeString)
 		if err != nil {
-			if _, r, err := parseValue(input, d.flags); err != nil {
+			if _, r, err := d.parseValue(input); err != nil {
 				return r, err
 			} else {
 				b = r
@@ -1118,7 +1118,7 @@ func (d decoder) decodeMapStringBool(b []byte, p unsafe.Pointer) ([]byte, error)
 
 		b, err = d.decodeBool(b, unsafe.Pointer(&val))
 		if err != nil {
-			if _, r, err := parseValue(input, d.flags); err != nil {
+			if _, r, err := d.parseValue(input); err != nil {
 				return r, err
 			} else {
 				b = r
@@ -1176,7 +1176,7 @@ func (d decoder) decodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 			return b, syntaxError(b, "cannot decode object key string from 'null' value")
 		}
 
-		k, b, _, err = parseStringUnquote(b, nil, d.flags)
+		k, b, _, err = d.parseStringUnquote(b, nil)
 		if err != nil {
 			return objectKeyError(b, err)
 		}
@@ -1201,14 +1201,14 @@ func (d decoder) decodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 			if (d.flags & DisallowUnknownFields) != 0 {
 				return b, fmt.Errorf("json: unknown field %q", k)
 			}
-			if _, b, err = parseValue(b, d.flags); err != nil {
+			if _, b, err = d.parseValue(b); err != nil {
 				return b, err
 			}
 			continue
 		}
 
 		if b, err = f.codec.decode(d, b, unsafe.Pointer(uintptr(p)+f.offset)); err != nil {
-			if _, r, err := parseValue(input, d.flags); err != nil {
+			if _, r, err := d.parseValue(input); err != nil {
 				return r, err
 			} else {
 				b = r
@@ -1277,7 +1277,7 @@ func (d decoder) decodeInterface(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b, err
 	}
 
-	v, b, err := parseValue(b, d.flags)
+	v, b, err := d.parseValue(b)
 	if err != nil {
 		return b, err
 	}
@@ -1352,7 +1352,7 @@ func (d decoder) decodeMaybeEmptyInterface(b []byte, p unsafe.Pointer, t reflect
 }
 
 func (d decoder) decodeUnmarshalTypeError(b []byte, p unsafe.Pointer, t reflect.Type) ([]byte, error) {
-	v, b, err := parseValue(b, d.flags)
+	v, b, err := d.parseValue(b)
 	if err != nil {
 		return b, err
 	}
@@ -1363,7 +1363,7 @@ func (d decoder) decodeUnmarshalTypeError(b []byte, p unsafe.Pointer, t reflect.
 }
 
 func (d decoder) decodeRawMessage(b []byte, p unsafe.Pointer) ([]byte, error) {
-	v, r, err := parseValue(b, d.flags)
+	v, r, err := d.parseValue(b)
 	if err != nil {
 		return d.inputError(b, rawMessageType)
 	}
@@ -1377,7 +1377,7 @@ func (d decoder) decodeRawMessage(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeJSONUnmarshaler(b []byte, p unsafe.Pointer, t reflect.Type, pointer bool) ([]byte, error) {
-	v, b, err := parseValue(b, d.flags)
+	v, b, err := d.parseValue(b)
 	if err != nil {
 		return b, err
 	}
@@ -1397,7 +1397,7 @@ func (d decoder) decodeJSONUnmarshaler(b []byte, p unsafe.Pointer, t reflect.Typ
 func (d decoder) decodeTextUnmarshaler(b []byte, p unsafe.Pointer, t reflect.Type, pointer bool) ([]byte, error) {
 	var value string
 
-	v, b, err := parseValue(b, d.flags)
+	v, b, err := d.parseValue(b)
 	if err != nil {
 		return b, err
 	}
@@ -1407,10 +1407,10 @@ func (d decoder) decodeTextUnmarshaler(b []byte, p unsafe.Pointer, t reflect.Typ
 
 	switch v[0] {
 	case 'n':
-		_, _, err := parseNull(v)
+		_, _, err := d.parseNull(v)
 		return b, err
 	case '"':
-		s, _, _, err := parseStringUnquote(v, nil, d.flags)
+		s, _, _, err := d.parseStringUnquote(v, nil)
 		if err != nil {
 			return b, err
 		}
@@ -1446,5 +1446,12 @@ func (d decoder) prependField(key, field string) string {
 }
 
 func (d decoder) inputError(b []byte, t reflect.Type) ([]byte, error) {
-	return inputError(b, t, d.flags)
+	if len(b) == 0 {
+		return nil, unexpectedEOF(b)
+	}
+	_, r, err := d.parseValue(b)
+	if err != nil {
+		return r, err
+	}
+	return skipSpaces(r), unmarshalTypeError(b, t)
 }

--- a/json/decode.go
+++ b/json/decode.go
@@ -17,7 +17,7 @@ func (d decoder) decodeNull(b []byte, p unsafe.Pointer) ([]byte, error) {
 	if hasNullPrefix(b) {
 		return b[4:], nil
 	}
-	return inputError(b, nullType)
+	return inputError(b, nullType, d.inputFlags)
 }
 
 func (d decoder) decodeBool(b []byte, p unsafe.Pointer) ([]byte, error) {
@@ -34,7 +34,7 @@ func (d decoder) decodeBool(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 
 	default:
-		return inputError(b, boolType)
+		return inputError(b, boolType, d.inputFlags)
 	}
 }
 
@@ -43,7 +43,7 @@ func (d decoder) decodeInt(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseInt(b, intType)
+	v, r, err := parseInt(b, intType, d.inputFlags)
 	if err != nil {
 		return r, err
 	}
@@ -57,7 +57,7 @@ func (d decoder) decodeInt8(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseInt(b, int8Type)
+	v, r, err := parseInt(b, int8Type, d.inputFlags)
 	if err != nil {
 		return r, err
 	}
@@ -75,7 +75,7 @@ func (d decoder) decodeInt16(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseInt(b, int16Type)
+	v, r, err := parseInt(b, int16Type, d.inputFlags)
 	if err != nil {
 		return r, err
 	}
@@ -93,7 +93,7 @@ func (d decoder) decodeInt32(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseInt(b, int32Type)
+	v, r, err := parseInt(b, int32Type, d.inputFlags)
 	if err != nil {
 		return r, err
 	}
@@ -111,7 +111,7 @@ func (d decoder) decodeInt64(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseInt(b, int64Type)
+	v, r, err := parseInt(b, int64Type, d.inputFlags)
 	if err != nil {
 		return r, err
 	}
@@ -125,7 +125,7 @@ func (d decoder) decodeUint(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseUint(b, uintType)
+	v, r, err := parseUint(b, uintType, d.inputFlags)
 	if err != nil {
 		return r, err
 	}
@@ -139,7 +139,7 @@ func (d decoder) decodeUintptr(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseUint(b, uintptrType)
+	v, r, err := parseUint(b, uintptrType, d.inputFlags)
 	if err != nil {
 		return r, err
 	}
@@ -153,7 +153,7 @@ func (d decoder) decodeUint8(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseUint(b, uint8Type)
+	v, r, err := parseUint(b, uint8Type, d.inputFlags)
 	if err != nil {
 		return r, err
 	}
@@ -171,7 +171,7 @@ func (d decoder) decodeUint16(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseUint(b, uint16Type)
+	v, r, err := parseUint(b, uint16Type, d.inputFlags)
 	if err != nil {
 		return r, err
 	}
@@ -189,7 +189,7 @@ func (d decoder) decodeUint32(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseUint(b, uint32Type)
+	v, r, err := parseUint(b, uint32Type, d.inputFlags)
 	if err != nil {
 		return r, err
 	}
@@ -207,7 +207,7 @@ func (d decoder) decodeUint64(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, err := parseUint(b, uint64Type)
+	v, r, err := parseUint(b, uint64Type, d.inputFlags)
 	if err != nil {
 		return r, err
 	}
@@ -223,12 +223,12 @@ func (d decoder) decodeFloat32(b []byte, p unsafe.Pointer) ([]byte, error) {
 
 	v, r, err := parseNumber(b)
 	if err != nil {
-		return inputError(b, float32Type)
+		return inputError(b, float32Type, d.inputFlags)
 	}
 
 	f, err := strconv.ParseFloat(*(*string)(unsafe.Pointer(&v)), 32)
 	if err != nil {
-		return inputError(b, float32Type)
+		return inputError(b, float32Type, d.inputFlags)
 	}
 
 	*(*float32)(p) = float32(f)
@@ -242,12 +242,12 @@ func (d decoder) decodeFloat64(b []byte, p unsafe.Pointer) ([]byte, error) {
 
 	v, r, err := parseNumber(b)
 	if err != nil {
-		return inputError(b, float64Type)
+		return inputError(b, float64Type, d.inputFlags)
 	}
 
 	f, err := strconv.ParseFloat(*(*string)(unsafe.Pointer(&v)), 64)
 	if err != nil {
-		return inputError(b, float64Type)
+		return inputError(b, float64Type, d.inputFlags)
 	}
 
 	*(*float64)(p) = f
@@ -261,7 +261,7 @@ func (d decoder) decodeNumber(b []byte, p unsafe.Pointer) ([]byte, error) {
 
 	v, r, err := parseNumber(b)
 	if err != nil {
-		return inputError(b, numberType)
+		return inputError(b, numberType, d.inputFlags)
 	}
 
 	if (d.flags & DontCopyNumber) != 0 {
@@ -278,10 +278,10 @@ func (d decoder) decodeString(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	s, r, new, err := parseStringUnquote(b, nil)
+	s, r, new, err := parseStringUnquote(b, nil, d.inputFlags)
 	if err != nil {
 		if len(b) == 0 || b[0] != '"' {
-			return inputError(b, stringType)
+			return inputError(b, stringType, d.inputFlags)
 		}
 		return r, err
 	}
@@ -300,9 +300,9 @@ func (d decoder) decodeFromString(b []byte, p unsafe.Pointer, decode decodeFunc)
 		return decode(d, b, p)
 	}
 
-	v, b, _, err := parseStringUnquote(b, nil)
+	v, b, _, err := parseStringUnquote(b, nil, d.inputFlags)
 	if err != nil {
-		return inputError(v, stringType)
+		return inputError(v, stringType, d.inputFlags)
 	}
 
 	if v, err = decode(d, v, p); err != nil {
@@ -349,9 +349,9 @@ func (d decoder) decodeFromStringToInt(b []byte, p unsafe.Pointer, t reflect.Typ
 		return b, fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal \"\" into int")
 	}
 
-	v, b, _, err := parseStringUnquote(b, nil)
+	v, b, _, err := parseStringUnquote(b, nil, d.inputFlags)
 	if err != nil {
-		return inputError(v, t)
+		return inputError(v, t, d.inputFlags)
 	}
 
 	if hasLeadingZeroes(v) {
@@ -387,7 +387,7 @@ func (d decoder) decodeFromStringToInt(b []byte, p unsafe.Pointer, t reflect.Typ
 		if _, _, err := parseNumber(v); err != nil {
 			// When the input value valid JSON we mirror the behavior of the
 			// encoding/json package and return a generic error.
-			if _, _, err := parseValue(v); err == nil {
+			if _, _, err := parseValue(v, d.inputFlags); err == nil {
 				return b, fmt.Errorf("json: invalid use of ,string struct tag, trying to unmarshal %q into int", prefix(v))
 			}
 		}
@@ -406,7 +406,7 @@ func (d decoder) decodeBytes(b []byte, p unsafe.Pointer) ([]byte, error) {
 	}
 
 	if len(b) < 2 {
-		return inputError(b, bytesType)
+		return inputError(b, bytesType, d.inputFlags)
 	}
 
 	if b[0] != '"' {
@@ -414,14 +414,14 @@ func (d decoder) decodeBytes(b []byte, p unsafe.Pointer) ([]byte, error) {
 		if len(b) > 0 && b[0] == '[' {
 			return d.decodeSlice(b, p, 1, bytesType, decoder.decodeUint8)
 		}
-		return inputError(b, bytesType)
+		return inputError(b, bytesType, d.inputFlags)
 	}
 
 	// The input string contains escaped sequences, we need to parse it before
 	// decoding it to match the encoding/json package behvaior.
-	src, r, _, err := parseStringUnquote(b, nil)
+	src, r, _, err := parseStringUnquote(b, nil, d.inputFlags)
 	if err != nil {
-		return inputError(b, bytesType)
+		return inputError(b, bytesType, d.inputFlags)
 	}
 
 	dst := make([]byte, base64.StdEncoding.DecodedLen(len(src)))
@@ -445,9 +445,9 @@ func (d decoder) decodeDuration(b []byte, p unsafe.Pointer) ([]byte, error) {
 	// flexible on how durations are formatted, but for the time being, it's
 	// been punted to go2 at the earliest: https://github.com/golang/go/issues/4712
 	if len(b) > 0 && b[0] != '"' {
-		v, r, err := parseInt(b, durationType)
+		v, r, err := parseInt(b, durationType, d.inputFlags)
 		if err != nil {
-			return inputError(b, int32Type)
+			return inputError(b, int32Type, d.inputFlags)
 		}
 
 		if v < math.MinInt64 || v > math.MaxInt64 {
@@ -459,19 +459,19 @@ func (d decoder) decodeDuration(b []byte, p unsafe.Pointer) ([]byte, error) {
 	}
 
 	if len(b) < 2 || b[0] != '"' {
-		return inputError(b, durationType)
+		return inputError(b, durationType, d.inputFlags)
 	}
 
 	i := bytes.IndexByte(b[1:], '"') + 1
 	if i <= 0 {
-		return inputError(b, durationType)
+		return inputError(b, durationType, d.inputFlags)
 	}
 
 	s := b[1:i] // trim quotes
 
 	v, err := time.ParseDuration(*(*string)(unsafe.Pointer(&s)))
 	if err != nil {
-		return inputError(b, durationType)
+		return inputError(b, durationType, d.inputFlags)
 	}
 
 	*(*time.Duration)(p) = v
@@ -484,19 +484,19 @@ func (d decoder) decodeTime(b []byte, p unsafe.Pointer) ([]byte, error) {
 	}
 
 	if len(b) < 2 || b[0] != '"' {
-		return inputError(b, timeType)
+		return inputError(b, timeType, d.inputFlags)
 	}
 
 	i := bytes.IndexByte(b[1:], '"') + 1
 	if i <= 0 {
-		return inputError(b, timeType)
+		return inputError(b, timeType, d.inputFlags)
 	}
 
 	s := b[1:i] // trim quotes
 
 	v, err := time.Parse(time.RFC3339Nano, *(*string)(unsafe.Pointer(&s)))
 	if err != nil {
-		return inputError(b, timeType)
+		return inputError(b, timeType, d.inputFlags)
 	}
 
 	*(*time.Time)(p) = v
@@ -509,7 +509,7 @@ func (d decoder) decodeArray(b []byte, p unsafe.Pointer, n int, size uintptr, t 
 	}
 
 	if len(b) < 2 || b[0] != '[' {
-		return inputError(b, t)
+		return inputError(b, t, d.inputFlags)
 	}
 	b = b[1:]
 
@@ -557,7 +557,7 @@ func (d decoder) decodeArray(b []byte, p unsafe.Pointer, n int, size uintptr, t 
 			return b[1:], nil
 		}
 
-		_, b, err = parseValue(b)
+		_, b, err = parseValue(b, d.inputFlags)
 		if err != nil {
 			return b, err
 		}
@@ -576,7 +576,7 @@ func (d decoder) decodeSlice(b []byte, p unsafe.Pointer, size uintptr, t reflect
 	}
 
 	if len(b) < 2 {
-		return inputError(b, t)
+		return inputError(b, t, d.inputFlags)
 	}
 
 	if b[0] != '[' {
@@ -586,7 +586,7 @@ func (d decoder) decodeSlice(b []byte, p unsafe.Pointer, size uintptr, t reflect
 		if t.Elem().Kind() == reflect.Uint8 {
 			return d.decodeBytes(b, p)
 		}
-		return inputError(b, t)
+		return inputError(b, t, d.inputFlags)
 	}
 
 	input := b
@@ -630,7 +630,7 @@ func (d decoder) decodeSlice(b []byte, p unsafe.Pointer, size uintptr, t reflect
 
 		b, err = decode(d, b, unsafe.Pointer(uintptr(s.data)+(uintptr(s.len)*size)))
 		if err != nil {
-			if _, r, err := parseValue(input); err != nil {
+			if _, r, err := parseValue(input, d.inputFlags); err != nil {
 				return r, err
 			} else {
 				b = r
@@ -653,7 +653,7 @@ func (d decoder) decodeMap(b []byte, p unsafe.Pointer, t, kt, vt reflect.Type, k
 	}
 
 	if len(b) < 2 || b[0] != '{' {
-		return inputError(b, t)
+		return inputError(b, t, d.inputFlags)
 	}
 	i := 0
 	m := reflect.NewAt(t, p).Elem()
@@ -709,7 +709,7 @@ func (d decoder) decodeMap(b []byte, p unsafe.Pointer, t, kt, vt reflect.Type, k
 		b = skipSpaces(b[1:])
 
 		if b, err = decodeValue(d, b, vptr); err != nil {
-			if _, r, err := parseValue(input); err != nil {
+			if _, r, err := parseValue(input, d.inputFlags); err != nil {
 				return r, err
 			} else {
 				b = r
@@ -733,7 +733,7 @@ func (d decoder) decodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, e
 	}
 
 	if len(b) < 2 || b[0] != '{' {
-		return inputError(b, mapStringInterfaceType)
+		return inputError(b, mapStringInterfaceType, d.inputFlags)
 	}
 
 	i := 0
@@ -790,7 +790,7 @@ func (d decoder) decodeMapStringInterface(b []byte, p unsafe.Pointer) ([]byte, e
 
 		b, err = d.decodeInterface(b, unsafe.Pointer(&val))
 		if err != nil {
-			if _, r, err := parseValue(input); err != nil {
+			if _, r, err := parseValue(input, d.inputFlags); err != nil {
 				return r, err
 			} else {
 				b = r
@@ -814,7 +814,7 @@ func (d decoder) decodeMapStringRawMessage(b []byte, p unsafe.Pointer) ([]byte, 
 	}
 
 	if len(b) < 2 || b[0] != '{' {
-		return inputError(b, mapStringRawMessageType)
+		return inputError(b, mapStringRawMessageType, d.inputFlags)
 	}
 
 	i := 0
@@ -871,7 +871,7 @@ func (d decoder) decodeMapStringRawMessage(b []byte, p unsafe.Pointer) ([]byte, 
 
 		b, err = d.decodeRawMessage(b, unsafe.Pointer(&val))
 		if err != nil {
-			if _, r, err := parseValue(input); err != nil {
+			if _, r, err := parseValue(input, d.inputFlags); err != nil {
 				return r, err
 			} else {
 				b = r
@@ -895,7 +895,7 @@ func (d decoder) decodeMapStringString(b []byte, p unsafe.Pointer) ([]byte, erro
 	}
 
 	if len(b) < 2 || b[0] != '{' {
-		return inputError(b, mapStringStringType)
+		return inputError(b, mapStringStringType, d.inputFlags)
 	}
 
 	i := 0
@@ -952,7 +952,7 @@ func (d decoder) decodeMapStringString(b []byte, p unsafe.Pointer) ([]byte, erro
 
 		b, err = d.decodeString(b, unsafe.Pointer(&val))
 		if err != nil {
-			if _, r, err := parseValue(input); err != nil {
+			if _, r, err := parseValue(input, d.inputFlags); err != nil {
 				return r, err
 			} else {
 				b = r
@@ -976,7 +976,7 @@ func (d decoder) decodeMapStringStringSlice(b []byte, p unsafe.Pointer) ([]byte,
 	}
 
 	if len(b) < 2 || b[0] != '{' {
-		return inputError(b, mapStringStringSliceType)
+		return inputError(b, mapStringStringSliceType, d.inputFlags)
 	}
 
 	i := 0
@@ -1034,7 +1034,7 @@ func (d decoder) decodeMapStringStringSlice(b []byte, p unsafe.Pointer) ([]byte,
 
 		b, err = d.decodeSlice(b, unsafe.Pointer(&buf), stringSize, sliceStringType, decoder.decodeString)
 		if err != nil {
-			if _, r, err := parseValue(input); err != nil {
+			if _, r, err := parseValue(input, d.inputFlags); err != nil {
 				return r, err
 			} else {
 				b = r
@@ -1061,7 +1061,7 @@ func (d decoder) decodeMapStringBool(b []byte, p unsafe.Pointer) ([]byte, error)
 	}
 
 	if len(b) < 2 || b[0] != '{' {
-		return inputError(b, mapStringBoolType)
+		return inputError(b, mapStringBoolType, d.inputFlags)
 	}
 
 	i := 0
@@ -1118,7 +1118,7 @@ func (d decoder) decodeMapStringBool(b []byte, p unsafe.Pointer) ([]byte, error)
 
 		b, err = d.decodeBool(b, unsafe.Pointer(&val))
 		if err != nil {
-			if _, r, err := parseValue(input); err != nil {
+			if _, r, err := parseValue(input, d.inputFlags); err != nil {
 				return r, err
 			} else {
 				b = r
@@ -1141,7 +1141,7 @@ func (d decoder) decodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 	}
 
 	if len(b) < 2 || b[0] != '{' {
-		return inputError(b, st.typ)
+		return inputError(b, st.typ, d.inputFlags)
 	}
 
 	var err error
@@ -1176,7 +1176,7 @@ func (d decoder) decodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 			return b, syntaxError(b, "cannot decode object key string from 'null' value")
 		}
 
-		k, b, _, err = parseStringUnquote(b, nil)
+		k, b, _, err = parseStringUnquote(b, nil, d.inputFlags)
 		if err != nil {
 			return objectKeyError(b, err)
 		}
@@ -1201,14 +1201,14 @@ func (d decoder) decodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 			if (d.flags & DisallowUnknownFields) != 0 {
 				return b, fmt.Errorf("json: unknown field %q", k)
 			}
-			if _, b, err = parseValue(b); err != nil {
+			if _, b, err = parseValue(b, d.inputFlags); err != nil {
 				return b, err
 			}
 			continue
 		}
 
 		if b, err = f.codec.decode(d, b, unsafe.Pointer(uintptr(p)+f.offset)); err != nil {
-			if _, r, err := parseValue(input); err != nil {
+			if _, r, err := parseValue(input, d.inputFlags); err != nil {
 				return r, err
 			} else {
 				b = r
@@ -1277,7 +1277,7 @@ func (d decoder) decodeInterface(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b, err
 	}
 
-	v, b, err := parseValue(b)
+	v, b, err := parseValue(b, d.inputFlags)
 	if err != nil {
 		return b, err
 	}
@@ -1352,7 +1352,7 @@ func (d decoder) decodeMaybeEmptyInterface(b []byte, p unsafe.Pointer, t reflect
 }
 
 func (d decoder) decodeUnmarshalTypeError(b []byte, p unsafe.Pointer, t reflect.Type) ([]byte, error) {
-	v, b, err := parseValue(b)
+	v, b, err := parseValue(b, d.inputFlags)
 	if err != nil {
 		return b, err
 	}
@@ -1363,9 +1363,9 @@ func (d decoder) decodeUnmarshalTypeError(b []byte, p unsafe.Pointer, t reflect.
 }
 
 func (d decoder) decodeRawMessage(b []byte, p unsafe.Pointer) ([]byte, error) {
-	v, r, err := parseValue(b)
+	v, r, err := parseValue(b, d.inputFlags)
 	if err != nil {
-		return inputError(b, rawMessageType)
+		return inputError(b, rawMessageType, d.inputFlags)
 	}
 
 	if (d.flags & DontCopyRawMessage) == 0 {
@@ -1377,7 +1377,7 @@ func (d decoder) decodeRawMessage(b []byte, p unsafe.Pointer) ([]byte, error) {
 }
 
 func (d decoder) decodeJSONUnmarshaler(b []byte, p unsafe.Pointer, t reflect.Type, pointer bool) ([]byte, error) {
-	v, b, err := parseValue(b)
+	v, b, err := parseValue(b, d.inputFlags)
 	if err != nil {
 		return b, err
 	}
@@ -1397,12 +1397,12 @@ func (d decoder) decodeJSONUnmarshaler(b []byte, p unsafe.Pointer, t reflect.Typ
 func (d decoder) decodeTextUnmarshaler(b []byte, p unsafe.Pointer, t reflect.Type, pointer bool) ([]byte, error) {
 	var value string
 
-	v, b, err := parseValue(b)
+	v, b, err := parseValue(b, d.inputFlags)
 	if err != nil {
 		return b, err
 	}
 	if len(v) == 0 {
-		return inputError(v, t)
+		return inputError(v, t, d.inputFlags)
 	}
 
 	switch v[0] {
@@ -1410,7 +1410,7 @@ func (d decoder) decodeTextUnmarshaler(b []byte, p unsafe.Pointer, t reflect.Typ
 		_, _, err := parseNull(v)
 		return b, err
 	case '"':
-		s, _, _, err := parseStringUnquote(v, nil)
+		s, _, _, err := parseStringUnquote(v, nil, d.inputFlags)
 		if err != nil {
 			return b, err
 		}

--- a/json/encode.go
+++ b/json/encode.go
@@ -843,7 +843,7 @@ func (e encoder) encodeRawMessage(b []byte, p unsafe.Pointer) ([]byte, error) {
 		s = v
 	} else {
 		var err error
-		s, _, err = parseValue(v)
+		s, _, err = parseValue(v, 0)
 		if err != nil {
 			return b, &UnsupportedValueError{Value: reflect.ValueOf(v), Str: err.Error()}
 		}
@@ -875,7 +875,7 @@ func (e encoder) encodeJSONMarshaler(b []byte, p unsafe.Pointer, t reflect.Type,
 		return b, err
 	}
 
-	s, _, err := parseValue(j)
+	s, _, err := parseValue(j, 0)
 	if err != nil {
 		return b, &MarshalerError{Type: t, Err: err}
 	}

--- a/json/encode.go
+++ b/json/encode.go
@@ -120,7 +120,8 @@ func (e encoder) encodeNumber(b []byte, p unsafe.Pointer) ([]byte, error) {
 		n = "0"
 	}
 
-	_, _, err := parseNumber(stringToBytes(string(n)))
+	d := decoder{}
+	_, _, err := d.parseNumber(stringToBytes(string(n)))
 	if err != nil {
 		return b, err
 	}
@@ -843,7 +844,8 @@ func (e encoder) encodeRawMessage(b []byte, p unsafe.Pointer) ([]byte, error) {
 		s = v
 	} else {
 		var err error
-		s, _, err = parseValue(v, 0)
+		d := decoder{}
+		s, _, err = d.parseValue(v)
 		if err != nil {
 			return b, &UnsupportedValueError{Value: reflect.ValueOf(v), Str: err.Error()}
 		}
@@ -875,7 +877,8 @@ func (e encoder) encodeJSONMarshaler(b []byte, p unsafe.Pointer, t reflect.Type,
 		return b, err
 	}
 
-	s, _, err := parseValue(j, 0)
+	d := decoder{}
+	s, _, err := d.parseValue(j)
 	if err != nil {
 		return b, &MarshalerError{Type: t, Err: err}
 	}

--- a/json/json.go
+++ b/json/json.go
@@ -316,10 +316,11 @@ const (
 func (dec *Decoder) readValue() (v []byte, err error) {
 	var n int
 	var r []byte
+	var flags inputFlags
 
 	for {
 		if len(dec.remain) != 0 {
-			v, r, err = parseValue(dec.remain, 0)
+			v, r, err = parseValue(dec.remain, flags)
 			if err == nil {
 				dec.remain, n = skipSpacesN(r)
 				dec.inputOffset += int64(len(v) + n)
@@ -363,6 +364,7 @@ func (dec *Decoder) readValue() (v []byte, err error) {
 			err = io.EOF
 		}
 		dec.remain, n = skipSpacesN(dec.buffer)
+		flags = inputFlagsFor(dec.remain)
 		dec.inputOffset += int64(n)
 		dec.err = err
 	}

--- a/json/parse.go
+++ b/json/parse.go
@@ -47,6 +47,9 @@ func (flags inputFlags) has(f inputFlags) bool {
 }
 
 func inputFlagsFor(b []byte) (flags inputFlags) {
+	// Don't consider surrounding whitespace
+	b = skipSpaces(b)
+	b = b[:len(b)-trailingSpaces(b)]
 	if ascii.ValidPrint(b) {
 		flags |= validAsciiPrint
 	}
@@ -72,6 +75,19 @@ func skipSpacesN(b []byte) ([]byte, int) {
 		}
 	}
 	return nil, 0
+}
+
+func trailingSpaces(b []byte) int {
+	i := len(b) - 1
+loop:
+	for ; i >= 0; i-- {
+		switch b[i] {
+		case sp, ht, nl, cr:
+		default:
+			break loop
+		}
+	}
+	return len(b) - (i + 1)
 }
 
 // parseInt parses a decimal representation of an int64 from b.

--- a/json/parse.go
+++ b/json/parse.go
@@ -27,7 +27,7 @@ const (
 func internalParseFlags(b []byte) (flags ParseFlags) {
 	// Don't consider surrounding whitespace
 	b = skipSpaces(b)
-	b = b[:len(b)-trailingSpaces(b)]
+	b = trimTrailingSpaces(b)
 	if ascii.ValidPrint(b) {
 		flags |= validAsciiPrint
 	}
@@ -55,7 +55,14 @@ func skipSpacesN(b []byte) ([]byte, int) {
 	return nil, 0
 }
 
-func trailingSpaces(b []byte) int {
+func trimTrailingSpaces(b []byte) []byte {
+	if len(b) > 0 && b[len(b)-1] <= 0x20 {
+		b = trimTrailingSpacesN(b)
+	}
+	return b
+}
+
+func trimTrailingSpacesN(b []byte) []byte {
 	i := len(b) - 1
 loop:
 	for ; i >= 0; i-- {
@@ -65,7 +72,7 @@ loop:
 			break loop
 		}
 	}
-	return len(b) - (i + 1)
+	return b[:i+1]
 }
 
 // parseInt parses a decimal representation of an int64 from b.

--- a/json/parse.go
+++ b/json/parse.go
@@ -432,7 +432,8 @@ func parseStringFast(b []byte, flags inputFlags) ([]byte, []byte, bool, error) {
 	if n <= 1 {
 		return nil, b[len(b):], false, syntaxError(b, "missing '\"' at the end of a string value")
 	}
-	if bytes.IndexByte(b[1:n], '\\') < 0 && ascii.ValidPrint(b[1:n]) {
+	if (flags.has(noBackslash) || bytes.IndexByte(b[1:n], '\\') < 0) &&
+		(flags.has(validAsciiPrint) || ascii.ValidPrint(b[1:n])) {
 		return b[:n], b[n:], false, nil
 	}
 

--- a/json/parse_test.go
+++ b/json/parse_test.go
@@ -24,7 +24,7 @@ func TestParseString(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.in, func(t *testing.T) {
-			out, ext, err := parseString([]byte(test.in))
+			out, ext, err := parseString([]byte(test.in), 0)
 
 			if test.err == "" {
 				if err != nil {
@@ -70,7 +70,7 @@ func TestParseStringUnquote(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.in, func(t *testing.T) {
-			out, ext, _, err := parseStringUnquote([]byte(test.in), nil)
+			out, ext, _, err := parseStringUnquote([]byte(test.in), nil, 0)
 
 			if err != nil {
 				t.Errorf("%s => %s", test.in, err)
@@ -135,7 +135,7 @@ func BenchmarkParseString(b *testing.B) {
 	s := []byte(`"__segment_internal"`)
 
 	for i := 0; i != b.N; i++ {
-		parseString(s)
+		parseString(s, 0)
 	}
 }
 

--- a/json/parse_test.go
+++ b/json/parse_test.go
@@ -22,9 +22,10 @@ func TestParseString(t *testing.T) {
 		{`"\u0"`, ``, ``, `json: unicode code point must have at least 4 characters: 0"`},
 	}
 
+	d := decoder{}
 	for _, test := range tests {
 		t.Run(test.in, func(t *testing.T) {
-			out, ext, err := parseString([]byte(test.in), 0)
+			out, ext, err := d.parseString([]byte(test.in))
 
 			if test.err == "" {
 				if err != nil {
@@ -68,9 +69,10 @@ func TestParseStringUnquote(t *testing.T) {
 		{`"\u0061\u0062\u0063"`, `abc`, ``},
 	}
 
+	d := decoder{}
 	for _, test := range tests {
 		t.Run(test.in, func(t *testing.T) {
-			out, ext, _, err := parseStringUnquote([]byte(test.in), nil, 0)
+			out, ext, _, err := d.parseStringUnquote([]byte(test.in), nil)
 
 			if err != nil {
 				t.Errorf("%s => %s", test.in, err)
@@ -134,8 +136,9 @@ func TestAppendToLower(t *testing.T) {
 func BenchmarkParseString(b *testing.B) {
 	s := []byte(`"__segment_internal"`)
 
+	d := decoder{}
 	for i := 0; i != b.N; i++ {
-		parseString(s, 0)
+		d.parseString(s)
 	}
 }
 

--- a/json/token.go
+++ b/json/token.go
@@ -77,8 +77,8 @@ type Tokenizer struct {
 	// Stack used to track entering and leaving arrays, objects, and keys.
 	stack *stack
 
-	// Flags containing information about the input.
-	flags inputFlags
+	// Parsing flags.
+	flags ParseFlags
 }
 
 // NewTokenizer constructs a new Tokenizer which reads its json input from b.
@@ -103,7 +103,7 @@ func (t *Tokenizer) Reset(b []byte) {
 	t.isKey = false
 	t.json = b
 	t.stack = nil
-	t.flags = inputFlagsFor(b)
+	t.flags = internalParseFlags(b)
 }
 
 // Next returns a new tokenizer pointing at the next token, or the zero-value of

--- a/json/token.go
+++ b/json/token.go
@@ -76,6 +76,9 @@ type Tokenizer struct {
 
 	// Stack used to track entering and leaving arrays, objects, and keys.
 	stack *stack
+
+	// Flags containing information about the input.
+	flags inputFlags
 }
 
 // NewTokenizer constructs a new Tokenizer which reads its json input from b.
@@ -100,6 +103,7 @@ func (t *Tokenizer) Reset(b []byte) {
 	t.isKey = false
 	t.json = b
 	t.stack = nil
+	t.flags = inputFlagsFor(b)
 }
 
 // Next returns a new tokenizer pointing at the next token, or the zero-value of
@@ -138,7 +142,7 @@ skipLoop:
 	switch t.json[0] {
 	case '"':
 		t.Delim = 0
-		t.Value, t.json, t.Err = parseString(t.json)
+		t.Value, t.json, t.Err = parseString(t.json, t.flags)
 	case 'n':
 		t.Delim = 0
 		t.Value, t.json, t.Err = parseNull(t.json)
@@ -254,7 +258,7 @@ func (v RawValue) Number() bool {
 
 // AppendUnquote writes the unquoted version of the string value in v into b.
 func (v RawValue) AppendUnquote(b []byte) []byte {
-	s, r, new, err := parseStringUnquote([]byte(v), b)
+	s, r, new, err := parseStringUnquote([]byte(v), b, 0)
 	if err != nil {
 		panic(err)
 	}

--- a/json/token.go
+++ b/json/token.go
@@ -77,12 +77,17 @@ type Tokenizer struct {
 	// Stack used to track entering and leaving arrays, objects, and keys.
 	stack *stack
 
-	// Parsing flags.
-	flags ParseFlags
+	// Decoder used for parsing.
+	decoder decoder
 }
 
 // NewTokenizer constructs a new Tokenizer which reads its json input from b.
-func NewTokenizer(b []byte) *Tokenizer { return &Tokenizer{json: b} }
+func NewTokenizer(b []byte) *Tokenizer {
+	return &Tokenizer{
+		json:    b,
+		decoder: decoder{flags: internalParseFlags(b)},
+	}
+}
 
 // Reset erases the state of t and re-initializes it with the json input from b.
 func (t *Tokenizer) Reset(b []byte) {
@@ -103,7 +108,7 @@ func (t *Tokenizer) Reset(b []byte) {
 	t.isKey = false
 	t.json = b
 	t.stack = nil
-	t.flags = internalParseFlags(b)
+	t.decoder = decoder{flags: internalParseFlags(b)}
 }
 
 // Next returns a new tokenizer pointing at the next token, or the zero-value of
@@ -142,19 +147,19 @@ skipLoop:
 	switch t.json[0] {
 	case '"':
 		t.Delim = 0
-		t.Value, t.json, t.Err = parseString(t.json, t.flags)
+		t.Value, t.json, t.Err = t.decoder.parseString(t.json)
 	case 'n':
 		t.Delim = 0
-		t.Value, t.json, t.Err = parseNull(t.json)
+		t.Value, t.json, t.Err = t.decoder.parseNull(t.json)
 	case 't':
 		t.Delim = 0
-		t.Value, t.json, t.Err = parseTrue(t.json)
+		t.Value, t.json, t.Err = t.decoder.parseTrue(t.json)
 	case 'f':
 		t.Delim = 0
-		t.Value, t.json, t.Err = parseFalse(t.json)
+		t.Value, t.json, t.Err = t.decoder.parseFalse(t.json)
 	case '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
 		t.Delim = 0
-		t.Value, t.json, t.Err = parseNumber(t.json)
+		t.Value, t.json, t.Err = t.decoder.parseNumber(t.json)
 	case '{', '}', '[', ']', ':', ',':
 		t.Delim, t.Value, t.json = Delim(t.json[0]), t.json[:1], t.json[1:]
 	default:
@@ -258,7 +263,8 @@ func (v RawValue) Number() bool {
 
 // AppendUnquote writes the unquoted version of the string value in v into b.
 func (v RawValue) AppendUnquote(b []byte) []byte {
-	s, r, new, err := parseStringUnquote([]byte(v), b, 0)
+	d := decoder{}
+	s, r, new, err := d.parseStringUnquote(v, b)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This PR updates `json.Parse()` to first look at the string to determine whether it's valid ASCII print and whether it contains a backslash. This information is then made available to the parsing routines, allowing them to take fast paths without having to check each of their inputs independently.

```
name           old time/op    new time/op    delta
CodeDecoder-4    6.71ms ± 3%    5.49ms ± 1%  -18.18%  (p=0.008 n=5+5)

name           old speed      new speed      delta
CodeDecoder-4   289MB/s ± 3%   354MB/s ± 1%  +22.19%  (p=0.008 n=5+5)
```

Preprocessing the input is quick thanks to SIMD optimized routines (https://github.com/segmentio/encoding/pull/66 and `bytes.IndexByte`). There are perhaps further improvements to be made by coalescing the passes into one.