### PR TITLE
Optimize decoders using json.Kind

### DIFF
--- a/json/encode.go
+++ b/json/encode.go
@@ -121,7 +121,7 @@ func (e encoder) encodeNumber(b []byte, p unsafe.Pointer) ([]byte, error) {
 	}
 
 	d := decoder{}
-	_, _, err := d.parseNumber(stringToBytes(string(n)))
+	_, _, _, err := d.parseNumber(stringToBytes(string(n)))
 	if err != nil {
 		return b, err
 	}
@@ -845,7 +845,7 @@ func (e encoder) encodeRawMessage(b []byte, p unsafe.Pointer) ([]byte, error) {
 	} else {
 		var err error
 		d := decoder{}
-		s, _, err = d.parseValue(v)
+		s, _, _, err = d.parseValue(v)
 		if err != nil {
 			return b, &UnsupportedValueError{Value: reflect.ValueOf(v), Str: err.Error()}
 		}
@@ -878,7 +878,7 @@ func (e encoder) encodeJSONMarshaler(b []byte, p unsafe.Pointer, t reflect.Type,
 	}
 
 	d := decoder{}
-	s, _, err := d.parseValue(j)
+	s, _, _, err := d.parseValue(j)
 	if err != nil {
 		return b, &MarshalerError{Type: t, Err: err}
 	}

--- a/json/json.go
+++ b/json/json.go
@@ -169,7 +169,7 @@ const (
 )
 
 // Class returns the class of k.
-func (k Kind) Class() Kind { return Kind(1 << (bits.Len(uint(k)) - 1)) }
+func (k Kind) Class() Kind { return Kind(1 << uint(bits.Len(uint(k))-1)) }
 
 // Append acts like Marshal but appends the json representation to b instead of
 // always reallocating a new slice.

--- a/json/json.go
+++ b/json/json.go
@@ -168,9 +168,8 @@ const (
 	Object Kind = 32 // Equivalent to Delim == '{'
 )
 
-func (k Kind) Class() Kind {
-	return k & Kind(1<<(bits.Len(uint(k))-1))
-}
+// Class returns the class of k.
+func (k Kind) Class() Kind { return k & Kind(1<<(bits.Len(uint(k))-1)) }
 
 // Append acts like Marshal but appends the json representation to b instead of
 // always reallocating a new slice.

--- a/json/json.go
+++ b/json/json.go
@@ -169,7 +169,7 @@ const (
 )
 
 // Class returns the class of k.
-func (k Kind) Class() Kind { return k & Kind(1<<(bits.Len(uint(k))-1)) }
+func (k Kind) Class() Kind { return Kind(1 << (bits.Len(uint(k)) - 1)) }
 
 // Append acts like Marshal but appends the json representation to b instead of
 // always reallocating a new slice.

--- a/json/json.go
+++ b/json/json.go
@@ -150,7 +150,9 @@ const (
 type Kind uint
 
 const (
-	Null Kind = 1 // Null is not zero, so we keep zero for "uninitialized".
+	Undefined Kind = 0
+
+	Null Kind = 1 // Null is not zero, so we keep zero for "undefined".
 
 	Bool  Kind = 2 // Bit two is set to 1, means it's a boolean.
 	False Kind = 2 // Bool + 0

--- a/json/json.go
+++ b/json/json.go
@@ -55,7 +55,7 @@ type UnsupportedValueError = json.UnsupportedValueError
 
 // AppendFlags is a type used to represent configuration options that can be
 // applied when formatting json output.
-type AppendFlags int
+type AppendFlags uint
 
 const (
 	// EscapeHTML is a formatting flag used to to escape HTML in json strings.
@@ -74,7 +74,7 @@ const (
 
 // ParseFlags is a type used to represent configuration options that can be
 // applied when parsing json input.
-type ParseFlags int
+type ParseFlags uint
 
 func (flags ParseFlags) has(f ParseFlags) bool {
 	return (flags & f) != 0
@@ -85,7 +85,7 @@ func (f ParseFlags) kind() Kind {
 }
 
 func (f ParseFlags) withKind(kind Kind) ParseFlags {
-	return (f & ^(0xFF << kindOffset)) | (ParseFlags(kind) << kindOffset)
+	return (f & ^(ParseFlags(0xFF) << kindOffset)) | (ParseFlags(kind) << kindOffset)
 }
 
 const (
@@ -143,7 +143,7 @@ const (
 	// Bit offset where the kind of the json value is stored.
 	//
 	// See Kind in token.go for the enum.
-	kindOffset = 16
+	kindOffset ParseFlags = 16
 )
 
 // Kind represents the different kinds of value that exist in JSON.

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1777,3 +1777,27 @@ func BenchmarkUnmarshalField(b *testing.B) {
 
 	b.Log(v)
 }
+
+func TestKind(t *testing.T) {
+	for _, test := range []struct {
+		kind  Kind
+		class Kind
+	}{
+		{kind: 0, class: 0},
+		{kind: Null, class: Null},
+		{kind: False, class: Bool},
+		{kind: True, class: Bool},
+		{kind: Num, class: Num},
+		{kind: Uint, class: Num},
+		{kind: Int, class: Num},
+		{kind: Float, class: Num},
+		{kind: String, class: String},
+		{kind: Unescaped, class: String},
+		{kind: Array, class: Array},
+		{kind: Object, class: Object},
+	} {
+		if class := test.kind.Class(); class != test.class {
+			t.Errorf("class of kind(%d) mismatch: want=%d got=%d", test.kind, test.class, class)
+		}
+	}
+}

--- a/json/parse.go
+++ b/json/parse.go
@@ -162,7 +162,7 @@ func (d decoder) parseInt(b []byte, t reflect.Type) (int64, []byte, error) {
 	if count < len(b) {
 		switch b[count] {
 		case '.', 'e', 'E': // was this actually a float?
-			v, r, err := d.parseNumber(b)
+			v, r, _, err := d.parseNumber(b)
 			if err != nil {
 				v, r = b[:count+1], b[count+1:]
 			}
@@ -214,7 +214,7 @@ func (d decoder) parseUint(b []byte, t reflect.Type) (uint64, []byte, error) {
 	if count < len(b) {
 		switch b[count] {
 		case '.', 'e', 'E': // was this actually a float?
-			v, r, err := d.parseNumber(b)
+			v, r, _, err := d.parseNumber(b)
 			if err != nil {
 				v, r = b[:count+1], b[count+1:]
 			}
@@ -280,45 +280,49 @@ parseLoop:
 	return value, b[count:], nil
 }
 
-func (d decoder) parseNull(b []byte) ([]byte, []byte, error) {
+func (d decoder) parseNull(b []byte) ([]byte, []byte, Kind, error) {
 	if hasNullPrefix(b) {
-		return b[:4], b[4:], nil
+		return b[:4], b[4:], Null, nil
 	}
 	if len(b) < 4 {
-		return nil, b[len(b):], unexpectedEOF(b)
+		return nil, b[len(b):], 0, unexpectedEOF(b)
 	}
-	return nil, b, syntaxError(b, "expected 'null' but found invalid token")
+	return nil, b, 0, syntaxError(b, "expected 'null' but found invalid token")
 }
 
-func (d decoder) parseTrue(b []byte) ([]byte, []byte, error) {
+func (d decoder) parseTrue(b []byte) ([]byte, []byte, Kind, error) {
 	if hasTruePrefix(b) {
-		return b[:4], b[4:], nil
+		return b[:4], b[4:], True, nil
 	}
 	if len(b) < 4 {
-		return nil, b[len(b):], unexpectedEOF(b)
+		return nil, b[len(b):], 0, unexpectedEOF(b)
 	}
-	return nil, b, syntaxError(b, "expected 'true' but found invalid token")
+	return nil, b, 0, syntaxError(b, "expected 'true' but found invalid token")
 }
 
-func (d decoder) parseFalse(b []byte) ([]byte, []byte, error) {
+func (d decoder) parseFalse(b []byte) ([]byte, []byte, Kind, error) {
 	if hasFalsePrefix(b) {
-		return b[:5], b[5:], nil
+		return b[:5], b[5:], False, nil
 	}
 	if len(b) < 5 {
-		return nil, b[len(b):], unexpectedEOF(b)
+		return nil, b[len(b):], 0, unexpectedEOF(b)
 	}
-	return nil, b, syntaxError(b, "expected 'false' but found invalid token")
+	return nil, b, 0, syntaxError(b, "expected 'false' but found invalid token")
 }
 
-func (d decoder) parseNumber(b []byte) (v, r []byte, err error) {
+func (d decoder) parseNumber(b []byte) (v, r []byte, kind Kind, err error) {
 	if len(b) == 0 {
 		r, err = b, unexpectedEOF(b)
 		return
 	}
 
+	// Assume it's an unsigned integer at first.
+	kind = Uint
+
 	i := 0
 	// sign
 	if b[i] == '-' {
+		kind = Int
 		i++
 	}
 
@@ -351,6 +355,7 @@ func (d decoder) parseNumber(b []byte) (v, r []byte, err error) {
 
 	// decimal part
 	if i < len(b) && b[i] == '.' {
+		kind = Float
 		i++
 		decimalStart := i
 
@@ -373,6 +378,7 @@ func (d decoder) parseNumber(b []byte) (v, r []byte, err error) {
 
 	// exponent part
 	if i < len(b) && (b[i] == 'e' || b[i] == 'E') {
+		kind = Float
 		i++
 
 		if i < len(b) {
@@ -421,21 +427,21 @@ func (d decoder) parseUnicode(b []byte) (rune, int, error) {
 	return rune(u), 4, nil
 }
 
-func (d decoder) parseStringFast(b []byte) ([]byte, []byte, bool, error) {
+func (d decoder) parseString(b []byte) ([]byte, []byte, Kind, error) {
 	if len(b) < 2 {
-		return nil, b[len(b):], false, unexpectedEOF(b)
+		return nil, b[len(b):], 0, unexpectedEOF(b)
 	}
 	if b[0] != '"' {
-		return nil, b, false, syntaxError(b, "expected '\"' at the beginning of a string value")
+		return nil, b, 0, syntaxError(b, "expected '\"' at the beginning of a string value")
 	}
 
 	n := bytes.IndexByte(b[1:], '"') + 2
 	if n <= 1 {
-		return nil, b[len(b):], false, syntaxError(b, "missing '\"' at the end of a string value")
+		return nil, b[len(b):], 0, syntaxError(b, "missing '\"' at the end of a string value")
 	}
 	if (d.flags.has(noBackslash) || bytes.IndexByte(b[1:n], '\\') < 0) &&
 		(d.flags.has(validAsciiPrint) || ascii.ValidPrint(b[1:n])) {
-		return b[:n], b[n:], false, nil
+		return b[:n], b[n:], Unescaped, nil
 	}
 
 	for i := 1; i < len(b); i++ {
@@ -447,41 +453,36 @@ func (d decoder) parseStringFast(b []byte) ([]byte, []byte, bool, error) {
 				case 'u':
 					_, n, err := d.parseUnicode(b[i+1:])
 					if err != nil {
-						return nil, b[i+1+n:], false, err
+						return nil, b[i+1+n:], 0, err
 					}
 					i += n
 				default:
-					return nil, b, false, syntaxError(b, "invalid character '%c' in string escape code", b[i])
+					return nil, b, 0, syntaxError(b, "invalid character '%c' in string escape code", b[i])
 				}
 			}
 
 		case '"':
-			return b[:i+1], b[i+1:], true, nil
+			return b[:i+1], b[i+1:], String, nil
 
 		default:
 			if b[i] < 0x20 {
-				return nil, b, false, syntaxError(b, "invalid character '%c' in string escape code", b[i])
+				return nil, b, 0, syntaxError(b, "invalid character '%c' in string escape code", b[i])
 			}
 		}
 	}
 
-	return nil, b[len(b):], false, syntaxError(b, "missing '\"' at the end of a string value")
-}
-
-func (d decoder) parseString(b []byte) ([]byte, []byte, error) {
-	s, b, _, err := d.parseStringFast(b)
-	return s, b, err
+	return nil, b[len(b):], 0, syntaxError(b, "missing '\"' at the end of a string value")
 }
 
 func (d decoder) parseStringUnquote(b []byte, r []byte) ([]byte, []byte, bool, error) {
-	s, b, escaped, err := d.parseStringFast(b)
+	s, b, k, err := d.parseString(b)
 	if err != nil {
 		return s, b, false, err
 	}
 
 	s = s[1 : len(s)-1] // trim the quotes
 
-	if !escaped {
+	if k == Unescaped {
 		return s, b, false, nil
 	}
 
@@ -572,13 +573,13 @@ func appendCoerceInvalidUTF8(b []byte, s []byte) []byte {
 	return b
 }
 
-func (d decoder) parseObject(b []byte) ([]byte, []byte, error) {
+func (d decoder) parseObject(b []byte) ([]byte, []byte, Kind, error) {
 	if len(b) < 2 {
-		return nil, b[len(b):], unexpectedEOF(b)
+		return nil, b[len(b):], 0, unexpectedEOF(b)
 	}
 
 	if b[0] != '{' {
-		return nil, b, syntaxError(b, "expected '{' at the beginning of an object value")
+		return nil, b, 0, syntaxError(b, "expected '{' at the beginning of an object value")
 	}
 
 	var err error
@@ -591,60 +592,60 @@ func (d decoder) parseObject(b []byte) ([]byte, []byte, error) {
 		b = skipSpaces(b)
 
 		if len(b) == 0 {
-			return nil, b, syntaxError(b, "cannot decode object from empty input")
+			return nil, b, 0, syntaxError(b, "cannot decode object from empty input")
 		}
 
 		if b[0] == '}' {
 			j := (n - len(b)) + 1
-			return a[:j], a[j:], nil
+			return a[:j], a[j:], Object, nil
 		}
 
 		if i != 0 {
 			if len(b) == 0 {
-				return nil, b, syntaxError(b, "unexpected EOF after object field value")
+				return nil, b, 0, syntaxError(b, "unexpected EOF after object field value")
 			}
 			if b[0] != ',' {
-				return nil, b, syntaxError(b, "expected ',' after object field value but found '%c'", b[0])
+				return nil, b, 0, syntaxError(b, "expected ',' after object field value but found '%c'", b[0])
 			}
 			b = skipSpaces(b[1:])
 			if len(b) == 0 {
-				return nil, b, unexpectedEOF(b)
+				return nil, b, 0, unexpectedEOF(b)
 			}
 			if b[0] == '}' {
-				return nil, b, syntaxError(b, "unexpected trailing comma after object field")
+				return nil, b, 0, syntaxError(b, "unexpected trailing comma after object field")
 			}
 		}
 
-		_, b, err = d.parseString(b)
+		_, b, _, err = d.parseString(b)
 		if err != nil {
-			return nil, b, err
+			return nil, b, 0, err
 		}
 		b = skipSpaces(b)
 
 		if len(b) == 0 {
-			return nil, b, syntaxError(b, "unexpected EOF after object field key")
+			return nil, b, 0, syntaxError(b, "unexpected EOF after object field key")
 		}
 		if b[0] != ':' {
-			return nil, b, syntaxError(b, "expected ':' after object field key but found '%c'", b[0])
+			return nil, b, 0, syntaxError(b, "expected ':' after object field key but found '%c'", b[0])
 		}
 		b = skipSpaces(b[1:])
 
-		_, b, err = d.parseValue(b)
+		_, b, _, err = d.parseValue(b)
 		if err != nil {
-			return nil, b, err
+			return nil, b, 0, err
 		}
 
 		i++
 	}
 }
 
-func (d decoder) parseArray(b []byte) ([]byte, []byte, error) {
+func (d decoder) parseArray(b []byte) ([]byte, []byte, Kind, error) {
 	if len(b) < 2 {
-		return nil, b[len(b):], unexpectedEOF(b)
+		return nil, b[len(b):], 0, unexpectedEOF(b)
 	}
 
 	if b[0] != '[' {
-		return nil, b, syntaxError(b, "expected '[' at the beginning of array value")
+		return nil, b, 0, syntaxError(b, "expected '[' at the beginning of array value")
 	}
 
 	var err error
@@ -657,61 +658,69 @@ func (d decoder) parseArray(b []byte) ([]byte, []byte, error) {
 		b = skipSpaces(b)
 
 		if len(b) == 0 {
-			return nil, b, syntaxError(b, "missing closing ']' after array value")
+			return nil, b, 0, syntaxError(b, "missing closing ']' after array value")
 		}
 
 		if b[0] == ']' {
 			j := (n - len(b)) + 1
-			return a[:j], a[j:], nil
+			return a[:j], a[j:], Array, nil
 		}
 
 		if i != 0 {
 			if len(b) == 0 {
-				return nil, b, syntaxError(b, "unexpected EOF after array element")
+				return nil, b, 0, syntaxError(b, "unexpected EOF after array element")
 			}
 			if b[0] != ',' {
-				return nil, b, syntaxError(b, "expected ',' after array element but found '%c'", b[0])
+				return nil, b, 0, syntaxError(b, "expected ',' after array element but found '%c'", b[0])
 			}
 			b = skipSpaces(b[1:])
 			if len(b) == 0 {
-				return nil, b, unexpectedEOF(b)
+				return nil, b, 0, unexpectedEOF(b)
 			}
 			if b[0] == ']' {
-				return nil, b, syntaxError(b, "unexpected trailing comma after object field")
+				return nil, b, 0, syntaxError(b, "unexpected trailing comma after object field")
 			}
 		}
 
-		_, b, err = d.parseValue(b)
+		_, b, _, err = d.parseValue(b)
 		if err != nil {
-			return nil, b, err
+			return nil, b, 0, err
 		}
 
 		i++
 	}
 }
 
-func (d decoder) parseValue(b []byte) ([]byte, []byte, error) {
-	if len(b) != 0 {
-		switch b[0] {
-		case '{':
-			return d.parseObject(b)
-		case '[':
-			return d.parseArray(b)
-		case '"':
-			return d.parseString(b)
-		case 'n':
-			return d.parseNull(b)
-		case 't':
-			return d.parseTrue(b)
-		case 'f':
-			return d.parseFalse(b)
-		case '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
-			return d.parseNumber(b)
-		default:
-			return nil, b, syntaxError(b, "invalid character '%c' looking for beginning of value", b[0])
-		}
+func (d decoder) parseValue(b []byte) ([]byte, []byte, Kind, error) {
+	if len(b) == 0 {
+		return nil, b, 0, syntaxError(b, "unexpected end of JSON input")
 	}
-	return nil, b, syntaxError(b, "unexpected end of JSON input")
+
+	var v []byte
+	var k Kind
+	var err error
+
+	switch b[0] {
+	case '{':
+		v, b, k, err = d.parseObject(b)
+	case '[':
+		k = Array
+		v, b, k, err = d.parseArray(b)
+	case '"':
+		v, b, k, err = d.parseString(b)
+	case 'n':
+		v, b, k, err = d.parseNull(b)
+	case 't':
+		v, b, k, err = d.parseTrue(b)
+	case 'f':
+		v, b, k, err = d.parseFalse(b)
+	case '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+		v, b, k, err = d.parseNumber(b)
+	default:
+		err = syntaxError(b, "invalid character '%c' looking for beginning of value", b[0])
+	}
+
+	return v, b, k, err
 }
 
 func hasNullPrefix(b []byte) bool {

--- a/json/parse_test.go
+++ b/json/parse_test.go
@@ -25,7 +25,7 @@ func TestParseString(t *testing.T) {
 	d := decoder{}
 	for _, test := range tests {
 		t.Run(test.in, func(t *testing.T) {
-			out, ext, err := d.parseString([]byte(test.in))
+			out, ext, _, err := d.parseString([]byte(test.in))
 
 			if test.err == "" {
 				if err != nil {

--- a/json/token.go
+++ b/json/token.go
@@ -16,31 +16,18 @@ import (
 // Here is a common pattern to use a tokenizer:
 //
 //	for t := json.NewTokenizer(b); t.Next(); {
-//		switch t.Delim {
-//		case '{':
+//		switch k := t.Kind(); k.Class() {
+//		case json.Null:
 //			...
-//		case '}':
+//		case json.Bool:
 //			...
-//		case '[':
+//		case json.Num:
 //			...
-//		case ']':
+//		case json.String:
 //			...
-//		case ':':
+//		case json.Array:
 //			...
-//		case ',':
-//			...
-//		}
-//
-//		switch {
-//		case t.Value.String():
-//			...
-//		case t.Value.Null():
-//			...
-//		case t.Value.True():
-//			...
-//		case t.Value.False():
-//			...
-//		case t.Value.Number():
+//		case json.Object:
 //			...
 //		}
 //	}


### PR DESCRIPTION
Follow up to our discussion in #72, this PR adds new APIs to the tokenizer to leverage the decoder flags and avoid doing multiple passes over string values.

I ported a program to use the new APIs, it is both simpler and faster:
```
name       old time/op    new time/op    delta
Unmarshal     916ns ± 1%     799ns ± 3%  -12.81%  (p=0.008 n=5+5)

name       old speed      new speed      delta
Unmarshal  68.8MB/s ± 1%  78.9MB/s ± 3%  +14.72%  (p=0.008 n=5+5)

name       old alloc/op   new alloc/op   delta
Unmarshal      410B ± 0%      408B ± 0%   -0.49%  (p=0.008 n=5+5)

name       old allocs/op  new allocs/op  delta
Unmarshal      5.00 ± 0%      4.00 ± 0%  -20.00%  (p=0.008 n=5+5)
```

Also ran a quick comparison to the master branch to verify that we aren't introducing any obvious regressions:
```
name         old time/op    new time/op    delta
CodeDecoder    10.0ms ± 4%    10.0ms ± 1%   ~     (p=1.000 n=5+5)

name         old speed      new speed      delta
CodeDecoder   193MB/s ± 4%   194MB/s ± 1%   ~     (p=1.000 n=5+5)

name         old alloc/op   new alloc/op   delta
CodeDecoder     443kB ± 0%     443kB ± 0%   ~     (p=0.810 n=5+5)

name         old allocs/op  new allocs/op  delta
CodeDecoder     12.8k ± 0%     12.8k ± 0%   ~     (p=0.714 n=5+5)
```

```
name                           old time/op    new time/op    delta
Unmarshal/*json.codeResponse2    5.98ms ± 4%    5.60ms ± 3%  -6.39%  (p=0.016 n=5+5)

name                           old speed      new speed      delta
Unmarshal/*json.codeResponse2   325MB/s ± 4%   347MB/s ± 3%  +6.81%  (p=0.016 n=5+5)

name                           old alloc/op   new alloc/op   delta
Unmarshal/*json.codeResponse2    5.41kB ± 5%    5.06kB ± 4%  -6.54%  (p=0.016 n=5+5)

name                           old allocs/op  new allocs/op  delta
Unmarshal/*json.codeResponse2      22.8 ± 5%      21.0 ± 5%  -7.89%  (p=0.024 n=5+5)
```

It looks like the change also has a positive impact on decoding in general (not sure if it's the switch to `hasNullPrefix` or the use of `Kind` in various places).