### PR TITLE
Optimize short string parsing

### DIFF
--- a/json/parse.go
+++ b/json/parse.go
@@ -2,7 +2,9 @@ package json
 
 import (
 	"bytes"
+	"encoding/binary"
 	"math"
+	"math/bits"
 	"reflect"
 	"unicode"
 	"unicode/utf16"
@@ -429,7 +431,24 @@ func (d decoder) parseStringFast(b []byte) ([]byte, []byte, bool, error) {
 		return nil, b, false, syntaxError(b, "expected '\"' at the beginning of a string value")
 	}
 
-	n := bytes.IndexByte(b[1:], '"') + 2
+	var n int
+	if len(b) >= 9 {
+		// This is an optimization for short strings. We read 8 bytes,
+		// and XOR each with 0x22 (") so that these bytes (and only
+		// these bytes) are now zero. We use the hasless(u,1) trick
+		// from https://graphics.stanford.edu/~seander/bithacks.html#ZeroInWord
+		// to determine whether any bytes are zero. Finally, we CTZ
+		// to find the index of that byte.
+		u := binary.LittleEndian.Uint64(b[1:])
+		u ^= 0x2222222222222222
+		mask := (u - 0x0101010101010101) & ^u & 0x8080808080808080
+		if mask != 0 {
+			n = bits.TrailingZeros64(mask)/8 + 2
+			goto found
+		}
+	}
+	n = bytes.IndexByte(b[1:], '"') + 2
+found:
 	if n <= 1 {
 		return nil, b[len(b):], false, syntaxError(b, "missing '\"' at the end of a string value")
 	}


### PR DESCRIPTION
We use the same SWAR technique used elsewhere in the repo to check 8 bytes for the end quote in a string, before falling back to `bytes.IndexByte`:

```
name           old time/op    new time/op    delta
CodeDecoder-4    5.30ms ± 3%    5.08ms ± 2%  -4.19%  (p=0.000 n=9+10)

name           old speed      new speed      delta
CodeDecoder-4   366MB/s ± 2%   382MB/s ± 2%  +4.36%  (p=0.000 n=9+10)
```

`IndexByte` is pretty quick, but it still has to load the input byte into an XMM register and shuffle it around before starting the routine, and then it also has various length checks to see whether to engage AVX2 or SSE. You also have the function call to consider.

I think it's worth always checking the first chunk of bytes and paying the minor penalty each time you parse a string — it's common to see short strings in object keys, for example.