### PR TITLE
run less benchmarks in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - checkout
       - run: go install golang.org/x/tools/cmd/benchcmp
       - run: go mod download
-      - run: make bench-simple
+      - run: make bench-simple count=1
 
 workflows:
   version: 2

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,10 @@ $(benchstat):
 
 # This compares segmentio/encoding/json to the standard golang encoding/json;
 # for more in-depth benchmarks, see the `benchmarks` directory.
+count ?= 5
 bench-simple: $(benchstat)
-	@go test -v -run '^$$' -bench /codeResponse -benchmem -benchtime 3s -cpu 1 ./json -package encoding/json -count 8 | tee /tmp/encoding-json.txt
-	@go test -v -run '^$$' -bench /codeResponse -benchmem -benchtime 3s -cpu 1 ./json -count 8 | tee /tmp/segmentio-encoding-json.txt
+	@go test -v -run '^$$' -bench '(Marshal|Unmarshal)$$/codeResponse' -benchmem -cpu 1 -count $(count) ./json -package encoding/json | tee /tmp/encoding-json.txt
+	@go test -v -run '^$$' -bench '(Marshal|Unmarshal)$$/codeResponse' -benchmem -cpu 1 -count $(count) ./json | tee /tmp/segmentio-encoding-json.txt
 	benchstat /tmp/encoding-json.txt /tmp/segmentio-encoding-json.txt
 
 bench-master: $(benchstat)


### PR DESCRIPTION
The CI runs are a bit slow because we run many iterations of the benchmarks. They are useful to run because they expose they stress the code, but it doesn't seem necessary to run them multiple times in CI (we are rarely consulting the results that are recorded there).

Limiting to a single run will reduce the time it takes to run builds on this repository.