### PR TITLE
Fast ISO8601 timestamp parsing

### DIFF
--- a/iso8601/parse.go
+++ b/iso8601/parse.go
@@ -71,6 +71,7 @@ const (
 	replace3 = mask3 ^ 0x3030303030000030
 
 	zero = 0x3030303030303030
+	nine = 0x3939393939393939
 	msb  = 0x8080808080808080
 )
 
@@ -86,7 +87,7 @@ func nonNumeric(u uint64) uint64 {
 	// when adding 0x46, include the MSB from the input bytes in the final mask.
 	// Remove all but the MSBs and then you're left with a mask where each
 	// non-numeric byte from the input has its MSB set in the output.
-	return ((u - zero) | (u + 0x4646464646464646) | u) & msb
+	return ((u - zero) | (u + (^uint64(msb) - nine)) | u) & msb
 }
 
 func daysSinceEpoch(year, month, day uint64) uint64 {

--- a/iso8601/parse.go
+++ b/iso8601/parse.go
@@ -70,9 +70,11 @@ const (
 	replace2 = mask2 ^ 0x0000300000300000
 	replace3 = mask3 ^ 0x3030303030000030
 
-	zero = 0x3030303030303030
-	nine = 0x3939393939393939
-	msb  = 0x8080808080808080
+	lsb = ^uint64(0) / 255
+	msb = lsb * 0x80
+
+	zero = lsb * '0'
+	nine = lsb * '9'
 )
 
 func match(u, mask uint64) bool {
@@ -87,7 +89,7 @@ func nonNumeric(u uint64) uint64 {
 	// when adding 0x46, include the MSB from the input bytes in the final mask.
 	// Remove all but the MSBs and then you're left with a mask where each
 	// non-numeric byte from the input has its MSB set in the output.
-	return ((u - zero) | (u + (^uint64(msb) - nine)) | u) & msb
+	return ((u - zero) | (u + (^msb - nine)) | u) & msb
 }
 
 func daysSinceEpoch(year, month, day uint64) uint64 {

--- a/iso8601/parse.go
+++ b/iso8601/parse.go
@@ -41,6 +41,13 @@ func Parse(input string) (time.Time, error) {
 
 		if month > 12 || day > 31 || hour >= 24 || minute >= 60 || second >= 60 {
 			goto fallback
+		} else if day == 31 {
+			switch month {
+			case 4, 6, 9, 11:
+				goto fallback
+			}
+		} else if month == 2 && day == 29 && !isLeapYear(year) {
+			goto fallback
 		}
 
 		unixSeconds := int64(daysSinceEpoch(year, month, day))*86400 + int64(hour*3600+minute*60+second)
@@ -97,6 +104,10 @@ func daysSinceEpoch(year, month, day uint64) uint64 {
 	monthDays := ((monthAdjusted+adjust)*62719 + 769) / 2048
 	leapDays := yearAdjusted/4 - yearAdjusted/100 + yearAdjusted/400
 	return yearAdjusted*365 + leapDays + monthDays + (day - 1) - 2472632
+}
+
+func isLeapYear(y uint64) bool {
+	return (y%4) == 0 && ((y%100) != 0 || (y%400) == 0)
 }
 
 func unsafeStringToBytes(s string) []byte {

--- a/iso8601/parse.go
+++ b/iso8601/parse.go
@@ -16,19 +16,17 @@ var (
 	errSecondOutOfRange = errors.New("second out of range")
 )
 
-// Parse parses an ISO8601 string, e.g. "2021-03-25T21:36:12Z".
+// Parse parses an ISO8601 timestamp, e.g. "2021-03-25T21:36:12Z".
 func Parse(input string) (time.Time, error) {
 	switch b := unsafeStringToBytes(input); len(b) {
-	case 20:
+	case 20: // YYYY-MM-DDTHH:MM:SSZ
 		t1 := binary.LittleEndian.Uint64(b)
 		t2 := binary.LittleEndian.Uint64(b[8:])
 		t3 := uint64(binary.LittleEndian.Uint32(b[16:]))
 
-		// Check for valid "YYYY-MM-DDTHH:MM:SSZ" separators by masking input
-		// with "    -  -  T  :  :  Z". If separators are all valid, replace
-		// them with a '0' (0x30) byte and check all bytes are now numeric.
-		// If it's not input we can handle on the fast path, pass it off to
-		// time.Parse().
+		// Check for valid separators by masking input with "    -  -  T  :  :  Z".
+		// If separators are all valid, replace them with a '0' (0x30) byte and
+		// check all bytes are now numeric.
 		if !match(t1, mask1) || !match(t2, mask2) || !match(t3, mask3) {
 			return time.Time{}, errInvalidTimestamp
 		}
@@ -55,15 +53,54 @@ func Parse(input string) (time.Time, error) {
 
 		unixSeconds := int64(daysSinceEpoch(year, month, day))*86400 + int64(hour*3600+minute*60+second)
 		return time.Unix(unixSeconds, 0), nil
-	}
 
-	return time.Parse(time.RFC3339Nano, input)
+	case 24: // YYYY-MM-DDTHH:MM:SS.MMMZ
+		t1 := binary.LittleEndian.Uint64(b)
+		t2 := binary.LittleEndian.Uint64(b[8:])
+		t4 := binary.LittleEndian.Uint64(b[16:])
+
+		// Check for valid separators by masking input with "    -  -  T  :  :  .   Z".
+		// If separators are all valid, replace them with a '0' (0x30) byte and
+		// check all bytes are now numeric.
+		if !match(t1, mask1) || !match(t2, mask2) || !match(t4, mask4) {
+			// Note that there
+			return time.Time{}, errInvalidTimestamp
+		}
+		t1 ^= replace1
+		t2 ^= replace2
+		t4 ^= replace4
+		if (nonNumeric(t1) | nonNumeric(t2) | nonNumeric(t4)) != 0 {
+			return time.Time{}, errInvalidTimestamp
+		}
+
+		t1 -= zero
+		t2 -= zero
+		t4 -= zero
+		year := (t1&0xF)*1000 + (t1>>8&0xF)*100 + (t1>>16&0xF)*10 + (t1 >> 24 & 0xF)
+		month := (t1>>40&0xF)*10 + (t1 >> 48 & 0xF)
+		day := (t2&0xF)*10 + (t2 >> 8 & 0xF)
+		hour := (t2>>24&0xF)*10 + (t2 >> 32 & 0xF)
+		minute := (t2>>48&0xF)*10 + (t2 >> 56)
+		second := (t4>>8&0xF)*10 + (t4 >> 16 & 0xF)
+		millis := (t4>>32&0xF)*100 + (t4>>40&0xF)*10 + (t4 >> 48)
+
+		if err := validate(year, month, day, hour, minute, second); err != nil {
+			return time.Time{}, err
+		}
+
+		unixSeconds := int64(daysSinceEpoch(year, month, day))*86400 + int64(hour*3600+minute*60+second)
+		return time.Unix(unixSeconds, int64(millis*1e6)), nil
+
+	default:
+		return time.Parse(time.RFC3339Nano, input)
+	}
 }
 
 const (
 	mask1 = 0x2d00002d00000000 // YYYY-MM-
 	mask2 = 0x00003a0000540000 // DDTHH:MM
 	mask3 = 0x000000005a00003a // :SSZ____
+	mask4 = 0x5a0000002e00003a // :SS.MMMZ
 
 	// Generate masks that replace the separators with a numeric byte.
 	// The input must have valid separators. XOR with the separator bytes
@@ -71,6 +108,7 @@ const (
 	replace1 = mask1 ^ 0x3000003000000000
 	replace2 = mask2 ^ 0x0000300000300000
 	replace3 = mask3 ^ 0x3030303030000030
+	replace4 = mask4 ^ 0x3000000030000030
 
 	lsb = ^uint64(0) / 255
 	msb = lsb * 0x80

--- a/iso8601/parse.go
+++ b/iso8601/parse.go
@@ -1,0 +1,106 @@
+package iso8601
+
+import (
+	"encoding/binary"
+	"time"
+	"unsafe"
+)
+
+// Parse parses an ISO8601 string, e.g. "2021-03-25T21:36:12Z".
+func Parse(input string) (time.Time, error) {
+	switch len(input) {
+	case 20:
+		b := unsafeStringToBytes(input)
+		_ = b[19] // compiler hint
+
+		t1 := binary.LittleEndian.Uint64(b)
+		t2 := binary.LittleEndian.Uint64(b[8:])
+		t3 := binary.LittleEndian.Uint32(b[16:])
+
+		// Check for valid "YYYY-MM-DDTHH:MM:SSZ" separators by masking input
+		// with "    -  -  T  :  :  Z". If separators are all valid, replace
+		// them with a '0' (0x30) byte and check all bytes are now numeric.
+		// If it's not input we can handle on the fast path, pass it off to
+		// time.Parse().
+		if (t1&sepMask1u64) != sepMask1u64 ||
+			(t2&sepMask2u64) != sepMask2u64 ||
+			(t3&sepMask3u32) != sepMask3u32 ||
+			nonNumeric64(t1 & ^sepMask1u64 | sepZero1u64) != 0 ||
+			nonNumeric64(t2 & ^sepMask2u64 | sepZero2u64) != 0 ||
+			nonNumeric32(t3 & ^sepMask3u32 | sepZero3u32) != 0 {
+
+			goto fallback
+		}
+
+		// TODO: there's probably a faster way to extract the integers, e.g. see
+		//  https://kholdstare.github.io/technical/2020/05/26/faster-integer-parsing.html
+		year := uint32(b[0]-'0')*1000 + uint32(b[1]-'0')*100 + uint32(b[2]-'0')*10 + uint32(b[3]-'0')
+		month := uint32(b[5]-'0')*10 + uint32(b[6]-'0')
+		day := uint32(b[8]-'0')*10 + uint32(b[9]-'0')
+		hour := uint32(b[11]-'0')*10 + uint32(b[12]-'0')
+		minute := uint32(b[14]-'0')*10 + uint32(b[15]-'0')
+		second := uint32(b[17]-'0')*10 + uint32(b[18]-'0')
+
+		// From https://blog.reverberate.org/2020/05/12/optimizing-date-algorithms.html.
+		monthAdjusted := month - 3
+		var carry uint32
+		if monthAdjusted > month {
+			carry = 1
+		}
+		var adjust uint32
+		if carry == 1 {
+			adjust = 12
+		}
+		yearAdjusted := year + 4800 - carry
+		monthDays := ((monthAdjusted+adjust)*62719 + 769) / 2048
+		leapDays := yearAdjusted/4 - yearAdjusted/100 + yearAdjusted/400
+		daysSinceEpoch := yearAdjusted*365 + leapDays + monthDays + (day - 1) - 2472632
+
+		return time.Unix(int64(daysSinceEpoch)*86400+int64(hour*3600+minute*60+second), 0), nil
+	}
+
+fallback:
+	return time.Parse(time.RFC3339Nano, input)
+}
+
+const (
+	sepMask1u64 = uint64(0x2d00002d00000000) // YYYY-MM-
+	sepMask2u64 = uint64(0x00003a0000540000) // DDTHH:MM
+	sepMask3u32 = uint32(0x5a00003a)         // :SSZ
+
+	sepZero1u64 = uint64(0x3000003000000000)
+	sepZero2u64 = uint64(0x0000300000300000)
+	sepZero3u32 = uint32(0x30000030)
+)
+
+func nonNumeric64(u uint64) uint64 {
+	// Derived from https://graphics.stanford.edu/~seander/bithacks.html#HasLessInWord.
+	// Subtract '0' (0x30) from each byte so that the MSB is set in each byte
+	// if there's a byte less than '0' (0x30). Add 0x46 (0x7F-'9') so that the
+	// MSB is set if there's a byte greater than '9' (0x39). To handle overflow
+	// when adding 0x46, include the MSB from the input bytes in the final mask.
+	// Remove all but the MSBs and then you're left with a mask where each
+	// non-numeric byte from the input has its MSB set in the output.
+	return ((u - 0x3030303030303030) | (u + 0x4646464646464646) | u) & 0x8080808080808080
+}
+
+func nonNumeric32(u uint32) uint32 {
+	return ((u - 0x30303030) | (u + 0x46464646) | u) & 0x80808080
+}
+
+func unsafeStringToBytes(s string) []byte {
+	return *(*[]byte)(unsafe.Pointer(&sliceHeader{
+		Data: *(*unsafe.Pointer)(unsafe.Pointer(&s)),
+		Len:  len(s),
+		Cap:  len(s),
+	}))
+}
+
+// sliceHeader is like reflect.SliceHeader but the Data field is a
+// unsafe.Pointer instead of being a uintptr to avoid invalid
+// conversions from uintptr to unsafe.Pointer.
+type sliceHeader struct {
+	Data unsafe.Pointer
+	Len  int
+	Cap  int
+}

--- a/iso8601/parse.go
+++ b/iso8601/parse.go
@@ -39,7 +39,7 @@ func Parse(input string) (time.Time, error) {
 		minute := (t2>>48&0xF)*10 + (t2 >> 56)
 		second := (t3>>8&0xF)*10 + (t3 >> 16)
 
-		if month > 12 || day > 31 || hour >= 24 || minute >= 60 || second >= 60 {
+		if month > 12 || day > 31 || hour >= 24 || minute >= 60 || second >= 60 || month == 0 || day == 0 {
 			goto fallback
 		} else if month == 2 && (day > 29 || (day == 29 && !isLeapYear(year))) {
 			goto fallback

--- a/iso8601/parse.go
+++ b/iso8601/parse.go
@@ -39,6 +39,10 @@ func Parse(input string) (time.Time, error) {
 		minute := (t2>>48&0xF)*10 + (t2 >> 56)
 		second := (t3>>8&0xF)*10 + (t3 >> 16)
 
+		if month > 12 || day > 31 || hour >= 24 || minute >= 60 || second >= 60 {
+			goto fallback
+		}
+
 		unixSeconds := int64(daysSinceEpoch(year, month, day))*86400 + int64(hour*3600+minute*60+second)
 		return time.Unix(unixSeconds, 0), nil
 	}
@@ -54,7 +58,7 @@ const (
 
 	// Generate masks that replace the separators with a numeric byte.
 	// The input must have valid separators. XOR with the separator bytes
-	// to zero them out and then XOR with 0x30 to replace them '0'.
+	// to zero them out and then XOR with 0x30 to replace them with '0'.
 	replace1 = mask1 ^ 0x3000003000000000
 	replace2 = mask2 ^ 0x0000300000300000
 	replace3 = mask3 ^ 0x3030303030000030
@@ -79,7 +83,7 @@ func nonNumeric(u uint64) uint64 {
 }
 
 func daysSinceEpoch(year, month, day uint64) uint64 {
-	// From https://blog.reverberate.org/2020/05/12/optimizing-date-algorithms.html.
+	// Derived from https://blog.reverberate.org/2020/05/12/optimizing-date-algorithms.html.
 	monthAdjusted := month - 3
 	var carry uint64
 	if monthAdjusted > month {

--- a/iso8601/parse.go
+++ b/iso8601/parse.go
@@ -8,26 +8,19 @@ import (
 
 // Parse parses an ISO8601 string, e.g. "2021-03-25T21:36:12Z".
 func Parse(input string) (time.Time, error) {
-	switch len(input) {
+	switch b := unsafeStringToBytes(input); len(b) {
 	case 20:
-		b := unsafeStringToBytes(input)
-		_ = b[19] // compiler hint
-
 		t1 := binary.LittleEndian.Uint64(b)
 		t2 := binary.LittleEndian.Uint64(b[8:])
-		t3 := binary.LittleEndian.Uint32(b[16:])
+		t3 := uint64(binary.LittleEndian.Uint32(b[16:]))
 
 		// Check for valid "YYYY-MM-DDTHH:MM:SSZ" separators by masking input
 		// with "    -  -  T  :  :  Z". If separators are all valid, replace
 		// them with a '0' (0x30) byte and check all bytes are now numeric.
 		// If it's not input we can handle on the fast path, pass it off to
 		// time.Parse().
-		if (t1&sepMask1u64) != sepMask1u64 ||
-			(t2&sepMask2u64) != sepMask2u64 ||
-			(t3&sepMask3u32) != sepMask3u32 ||
-			nonNumeric64(t1 & ^sepMask1u64 | sepZero1u64) != 0 ||
-			nonNumeric64(t2 & ^sepMask2u64 | sepZero2u64) != 0 ||
-			nonNumeric32(t3 & ^sepMask3u32 | sepZero3u32) != 0 {
+		if !match(t1, mask1) || !match(t2, mask2) || !match(t3, mask3) ||
+			(nonNumeric(t1^zero1)|nonNumeric(t2^zero2)|nonNumeric(t3^zero3)) != 0 {
 
 			goto fallback
 		}
@@ -41,22 +34,8 @@ func Parse(input string) (time.Time, error) {
 		minute := uint32(b[14]-'0')*10 + uint32(b[15]-'0')
 		second := uint32(b[17]-'0')*10 + uint32(b[18]-'0')
 
-		// From https://blog.reverberate.org/2020/05/12/optimizing-date-algorithms.html.
-		monthAdjusted := month - 3
-		var carry uint32
-		if monthAdjusted > month {
-			carry = 1
-		}
-		var adjust uint32
-		if carry == 1 {
-			adjust = 12
-		}
-		yearAdjusted := year + 4800 - carry
-		monthDays := ((monthAdjusted+adjust)*62719 + 769) / 2048
-		leapDays := yearAdjusted/4 - yearAdjusted/100 + yearAdjusted/400
-		daysSinceEpoch := yearAdjusted*365 + leapDays + monthDays + (day - 1) - 2472632
-
-		return time.Unix(int64(daysSinceEpoch)*86400+int64(hour*3600+minute*60+second), 0), nil
+		unixSeconds := int64(daysSinceEpoch(year, month, day)) + int64(hour*3600+minute*60+second)
+		return time.Unix(unixSeconds, 0), nil
 	}
 
 fallback:
@@ -64,16 +43,26 @@ fallback:
 }
 
 const (
-	sepMask1u64 = uint64(0x2d00002d00000000) // YYYY-MM-
-	sepMask2u64 = uint64(0x00003a0000540000) // DDTHH:MM
-	sepMask3u32 = uint32(0x5a00003a)         // :SSZ
+	mask1 = 0x2d00002d00000000 // YYYY-MM-
+	mask2 = 0x00003a0000540000 // DDTHH:MM
+	mask3 = 0x000000005a00003a // :SSZ____
 
-	sepZero1u64 = uint64(0x3000003000000000)
-	sepZero2u64 = uint64(0x0000300000300000)
-	sepZero3u32 = uint32(0x30000030)
+	// Generate masks that replace the separators with a numeric byte.
+	// The input must have valid separators. XOR with the separator bytes
+	// to zero them out and then XOR with 0x30 to replace them '0'.
+	zero1 = mask1 ^ 0x3000003000000000
+	zero2 = mask2 ^ 0x0000300000300000
+	zero3 = mask3 ^ 0x3030303030000030
+
+	zero = 0x3030303030303030
+	msb  = 0x8080808080808080
 )
 
-func nonNumeric64(u uint64) uint64 {
+func match(u, mask uint64) bool {
+	return (u & mask) == mask
+}
+
+func nonNumeric(u uint64) uint64 {
 	// Derived from https://graphics.stanford.edu/~seander/bithacks.html#HasLessInWord.
 	// Subtract '0' (0x30) from each byte so that the MSB is set in each byte
 	// if there's a byte less than '0' (0x30). Add 0x46 (0x7F-'9') so that the
@@ -81,11 +70,24 @@ func nonNumeric64(u uint64) uint64 {
 	// when adding 0x46, include the MSB from the input bytes in the final mask.
 	// Remove all but the MSBs and then you're left with a mask where each
 	// non-numeric byte from the input has its MSB set in the output.
-	return ((u - 0x3030303030303030) | (u + 0x4646464646464646) | u) & 0x8080808080808080
+	return ((u - zero) | (u + 0x4646464646464646) | u) & msb
 }
 
-func nonNumeric32(u uint32) uint32 {
-	return ((u - 0x30303030) | (u + 0x46464646) | u) & 0x80808080
+func daysSinceEpoch(year, month, day uint32) uint32 {
+	// Derived from https://blog.reverberate.org/2020/05/12/optimizing-date-algorithms.html.
+	monthAdjusted := month - 3
+	var carry uint32
+	if monthAdjusted > month {
+		carry = 1
+	}
+	var adjust uint32
+	if carry == 1 {
+		adjust = 12
+	}
+	yearAdjusted := year + 4800 - carry
+	monthDays := ((monthAdjusted+adjust)*62719 + 769) / 2048
+	leapDays := yearAdjusted/4 - yearAdjusted/100 + yearAdjusted/400
+	return yearAdjusted*365 + leapDays + monthDays + (day - 1) - 2472632
 }
 
 func unsafeStringToBytes(s string) []byte {

--- a/iso8601/parse.go
+++ b/iso8601/parse.go
@@ -41,13 +41,13 @@ func Parse(input string) (time.Time, error) {
 
 		if month > 12 || day > 31 || hour >= 24 || minute >= 60 || second >= 60 {
 			goto fallback
+		} else if month == 2 && (day > 29 || (day == 29 && !isLeapYear(year))) {
+			goto fallback
 		} else if day == 31 {
 			switch month {
 			case 4, 6, 9, 11:
 				goto fallback
 			}
-		} else if month == 2 && day == 29 && !isLeapYear(year) {
-			goto fallback
 		}
 
 		unixSeconds := int64(daysSinceEpoch(year, month, day))*86400 + int64(hour*3600+minute*60+second)

--- a/iso8601/parse_test.go
+++ b/iso8601/parse_test.go
@@ -7,6 +7,7 @@ import (
 
 func TestParse(t *testing.T) {
 	for _, input := range []string{
+		"1987-12-16T23:45:12Z",
 		"2006-01-02T15:04:05Z",
 		"2006-01-02T15:04:05.123Z",
 		"2006-01-02T15:04:05.123456Z",

--- a/iso8601/parse_test.go
+++ b/iso8601/parse_test.go
@@ -1,6 +1,7 @@
 package iso8601
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -34,6 +35,22 @@ func TestParse(t *testing.T) {
 				t.Errorf("unexpected time: %v vs expected %v", actual, expect)
 			}
 		})
+	}
+
+	// Check all ~3.7M YYYY-MM-DD dates
+	for year := 0; year <= 9999; year++ {
+		for month := 1; month <= 12; month++ {
+			for day := 1; day <= 31; day++ {
+				input := fmt.Sprintf("%04d-%02d-%02dT00:00:00Z", year, month, day)
+				expect, expectErr := time.Parse(time.RFC3339Nano, input)
+				actual, actualErr := Parse(input)
+				if (expectErr != nil) != (actualErr != nil) {
+					t.Errorf("unexpected error for %v: %v vs. %v expected", input, actualErr, expectErr)
+				} else if !actual.Equal(expect) {
+					t.Errorf("unexpected time for %v: %v vs. %v expected", input, actual, expect)
+				}
+			}
+		}
 	}
 }
 

--- a/iso8601/parse_test.go
+++ b/iso8601/parse_test.go
@@ -72,6 +72,8 @@ func TestParse(t *testing.T) {
 
 func TestParseInvalid(t *testing.T) {
 	for _, input := range []string{
+		"XXXXXXXXXXXXXXXXXXXX",
+		"00000000000000000000",
 		"1900-02-29T00:00:00Z", // 28 days in month (not a leap year)
 		"2021-02-29T00:00:00Z", // 28 days in month (not a leap year)
 		"2021-02-30T00:00:00Z", // 28 days in month
@@ -87,6 +89,10 @@ func TestParseInvalid(t *testing.T) {
 		"2000-12-31T24:00:00Z", // invalid hour
 		"2000-12-31T23:60:00Z", // invalid minute
 		"2000-12-31T23:59:60Z", // invalid second
+		"1999-01-01 23:45:00Z", // missing T separator
+		"1999 01 01T23:45:00Z", // missing date separators
+		"1999-01-01T23 45 00Z", // missing time separators
+		"1999-01-01T23:45:00 ", // missing timezone
 	} {
 		t.Run(input, func(t *testing.T) {
 			ts, err := time.Parse(time.RFC3339Nano, input)

--- a/iso8601/parse_test.go
+++ b/iso8601/parse_test.go
@@ -10,6 +10,7 @@ func TestParse(t *testing.T) {
 		// Fast path
 		"1987-12-16T23:45:12Z",
 		"2006-01-02T15:04:05Z",
+		"2000-02-29T23:59:59Z", // leap year
 		"2020-02-29T23:59:59Z", // leap year
 		"0000-01-01T00:00:00Z",
 		"9999-12-31T23:59:59Z",
@@ -20,13 +21,6 @@ func TestParse(t *testing.T) {
 		"2006-01-02T15:04:05.123+00:00",
 		"2006-01-02T15:04:05.123456Z",
 		"2006-01-02T15:04:05.123456789Z",
-
-		// FIXME:
-		// "2021-02-29T00:00:00Z", // not a leap year
-		// "2021-04-31T00:00:00Z", // 30 days in month
-		// "2021-06-31T00:00:00Z", // 30 days in month
-		// "2021-09-31T00:00:00Z", // 30 days in month
-		// "2021-11-31T00:00:00Z", // 30 days in month
 	} {
 		t.Run(input, func(t *testing.T) {
 			expect, err := time.Parse(time.RFC3339Nano, input)
@@ -38,6 +32,35 @@ func TestParse(t *testing.T) {
 				t.Error(err)
 			} else if !actual.Equal(expect) {
 				t.Errorf("unexpected time: %v vs expected %v", actual, expect)
+			}
+		})
+	}
+}
+
+func TestParseInvalid(t *testing.T) {
+	for _, input := range []string{
+		"1900-02-29T00:00:00Z", // not a leap year
+		"2021-02-29T00:00:00Z", // not a leap year
+		"2021-04-31T00:00:00Z", // 30 days in month
+		"2021-06-31T00:00:00Z", // 30 days in month
+		"2021-09-31T00:00:00Z", // 30 days in month
+		"2021-11-31T00:00:00Z", // 30 days in month
+		"2000-13-01T00:00:00Z", // invalid month
+		"2000-12-32T00:00:00Z", // invalid day
+		"2000-12-31T24:00:00Z", // invalid hour
+		"2000-12-31T23:60:00Z", // invalid minute
+		"2000-12-31T23:59:60Z", // invalid second
+	} {
+		t.Run(input, func(t *testing.T) {
+			ts, err := time.Parse(time.RFC3339Nano, input)
+			if err == nil {
+				t.Fatalf("expected time.Parse('%s') error, got %v", input, ts)
+			}
+			ts, actualErr := Parse(input)
+			if actualErr == nil {
+				t.Fatalf("expected Parse('%s') error %v, got %v", input, err, ts)
+			} else if err.Error() != actualErr.Error() {
+				t.Fatalf("expected Parse('%s') error %v, got %v", input, err, actualErr)
 			}
 		})
 	}

--- a/iso8601/parse_test.go
+++ b/iso8601/parse_test.go
@@ -107,9 +107,15 @@ func TestParseInvalid(t *testing.T) {
 	}
 }
 
-func BenchmarkParseSeconds(b *testing.B) {
+func BenchmarkParse(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		Parse("2006-01-02T15:04:05Z")
+	}
+}
+
+func BenchmarkParseInvalid(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Parse("2006-01-02T15:04:05X")
 	}
 }
 

--- a/iso8601/parse_test.go
+++ b/iso8601/parse_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestParse(t *testing.T) {
 	for _, input := range []string{
-		// Fast path
+		// Fast path (20 bytes)
 		"1987-12-16T23:45:12Z",
 		"2006-01-02T15:04:05Z",
 		"2000-02-29T23:59:59Z", // leap year
@@ -16,10 +16,19 @@ func TestParse(t *testing.T) {
 		"0000-01-01T00:00:00Z",
 		"9999-12-31T23:59:59Z",
 
+		// Fast path (24 bytes)
+		"1987-12-16T23:45:12.123Z",
+		"2006-01-02T15:04:05.123Z",
+		"2000-02-29T23:59:59.123Z",
+		"2020-02-29T23:59:59.123Z",
+		"0000-01-01T00:00:00.000Z",
+		"9999-12-31T23:59:59.999Z",
+
 		// Slow path
 		"2006-01-02T15:04:05+00:00",
-		"2006-01-02T15:04:05.123Z",
-		"2006-01-02T15:04:05.123+00:00",
+		"2006-01-02T15:04:05-07:00",
+		"2006-01-02T15:04:05.123+10:00",
+		"2006-01-02T15:04:05.123-08:00",
 		"2006-01-02T15:04:05.123456Z",
 		"2006-01-02T15:04:05.123456789Z",
 	} {
@@ -37,11 +46,11 @@ func TestParse(t *testing.T) {
 		})
 	}
 
-	// Check ~4M YYYY-MM-DD dates.
+	// Check ~4M YYYY-MM-DD dates in 20 byte form.
 	for year := 0; year <= 9999; year++ {
 		for month := 0; month <= 13; month++ {
 			for day := 0; day <= 32; day++ {
-				input := fmt.Sprintf("%04d-%02d-%02dT00:00:00Z", year, month, day)
+				input := fmt.Sprintf("%04d-%02d-%02dT12:34:56Z", year, month, day)
 				expect, expectErr := time.Parse(time.RFC3339Nano, input)
 				actual, actualErr := Parse(input)
 				if (expectErr != nil) != (actualErr != nil) {
@@ -53,7 +62,23 @@ func TestParse(t *testing.T) {
 		}
 	}
 
-	// Check all ~1M HH:MM:SS times.
+	// Check ~4M YYYY-MM-DD dates in 24 byte form.
+	for year := 0; year <= 9999; year++ {
+		for month := 0; month <= 13; month++ {
+			for day := 0; day <= 32; day++ {
+				input := fmt.Sprintf("%04d-%02d-%02dT12:34:56.789Z", year, month, day)
+				expect, expectErr := time.Parse(time.RFC3339Nano, input)
+				actual, actualErr := Parse(input)
+				if (expectErr != nil) != (actualErr != nil) {
+					t.Errorf("unexpected error for %v: %v vs. %v expected", input, actualErr, expectErr)
+				} else if !actual.Equal(expect) {
+					t.Errorf("unexpected time for %v: %v vs. %v expected", input, actual, expect)
+				}
+			}
+		}
+	}
+
+	// Check all ~1M HH:MM:SS times in 20 byte form.
 	for hour := 0; hour < 100; hour++ {
 		for minute := 0; minute < 100; minute++ {
 			for second := 0; second < 100; second++ {
@@ -68,10 +93,27 @@ func TestParse(t *testing.T) {
 			}
 		}
 	}
+
+	// Check ~1M HH:MM:SS.MMM times in 24 byte form.
+	for hour := 0; hour < 100; hour++ {
+		for minute := 0; minute < 100; minute++ {
+			for second := 0; second < 100; second++ {
+				input := fmt.Sprintf("2000-01-01T%02d-%02d-%02d.123Z", hour, minute, second)
+				expect, expectErr := time.Parse(time.RFC3339Nano, input)
+				actual, actualErr := Parse(input)
+				if (expectErr != nil) != (actualErr != nil) {
+					t.Errorf("unexpected error for %v: %v vs. %v expected", input, actualErr, expectErr)
+				} else if !actual.Equal(expect) {
+					t.Errorf("unexpected time for %v: %v vs. %v expected", input, actual, expect)
+				}
+			}
+		}
+	}
 }
 
 func TestParseInvalid(t *testing.T) {
 	for _, input := range []string{
+		// 20 bytes
 		"XXXXXXXXXXXXXXXXXXXX",
 		"00000000000000000000",
 		"1900-02-29T00:00:00Z", // 28 days in month (not a leap year)
@@ -82,17 +124,61 @@ func TestParseInvalid(t *testing.T) {
 		"2021-06-31T00:00:00Z", // 30 days in month
 		"2021-09-31T00:00:00Z", // 30 days in month
 		"2021-11-31T00:00:00Z", // 30 days in month
-		"2000-13-01T00:00:00Z", // invalid month
-		"2000-00-01T00:00:00Z", // invalid month
-		"2000-12-32T00:00:00Z", // invalid day
-		"2000-12-00T00:00:00Z", // invalid day
-		"2000-12-31T24:00:00Z", // invalid hour
-		"2000-12-31T23:60:00Z", // invalid minute
-		"2000-12-31T23:59:60Z", // invalid second
+		"XXXX-13-01T00:00:00Z", // invalid year
+		"2000-13-01T00:00:00Z", // invalid month (1)
+		"2000-00-01T00:00:00Z", // invalid month (2)
+		"2000-XX-01T00:00:00Z", // invalid month (3)
+		"2000-12-32T00:00:00Z", // invalid day (1)
+		"2000-12-00T00:00:00Z", // invalid day (2)
+		"2000-12-XXT00:00:00Z", // invalid day (3)
+		"2000-12-31T24:00:00Z", // invalid hour (1)
+		"2000-12-31TXX:00:00Z", // invalid hour (2)
+		"2000-12-31T23:60:00Z", // invalid minute (1)
+		"2000-12-31T23:XX:00Z", // invalid minute (2)
+		"2000-12-31T23:59:60Z", // invalid second (1)
+		"2000-12-31T23:59:XXZ", // invalid second (2)
 		"1999-01-01 23:45:00Z", // missing T separator
-		"1999 01 01T23:45:00Z", // missing date separators
-		"1999-01-01T23 45 00Z", // missing time separators
+		"1999 01-01T23:45:00Z", // missing date separator (1)
+		"1999-01 01T23:45:00Z", // missing date separator (2)
+		"1999-01-01T23 45:00Z", // missing time separator (1)
+		"1999-01-01T23:45 00Z", // missing time separator (2)
 		"1999-01-01T23:45:00 ", // missing timezone
+		"1999-01-01t23:45:00Z", // lowercase T
+		"1999-01-01T23:45:00z", // lowercase Z
+
+		// 24 bytes
+		"XXXXXXXXXXXXXXXXXXXXXXXX",
+		"000000000000000000000000",
+		"1900-02-29T00:00:00.123Z", // 28 days in month (not a leap year)
+		"2021-02-29T00:00:00.123Z", // 28 days in month (not a leap year)
+		"2021-02-30T00:00:00.123Z", // 28 days in month
+		"2021-02-31T00:00:00.123Z", // 28 days in month
+		"2021-04-31T00:00:00.123Z", // 30 days in month
+		"2021-06-31T00:00:00.123Z", // 30 days in month
+		"2021-09-31T00:00:00.123Z", // 30 days in month
+		"2021-11-31T00:00:00.123Z", // 30 days in month
+		"XXXX-13-01T00:00:00.123Z", // invalid year
+		"2000-13-01T00:00:00.123Z", // invalid month (1)
+		"2000-00-01T00:00:00.123Z", // invalid month (2)
+		"2000-XX-01T00:00:00.123Z", // invalid month (3)
+		"2000-12-32T00:00:00.123Z", // invalid day (1)
+		"2000-12-00T00:00:00.123Z", // invalid day (2)
+		"2000-12-XXT00:00:00.123Z", // invalid day (3)
+		"2000-12-31T24:00:00.123Z", // invalid hour (1)
+		"2000-12-31TXX:00:00.123Z", // invalid hour (2)
+		"2000-12-31T23:60:00.123Z", // invalid minute (1)
+		"2000-12-31T23:XX:00.123Z", // invalid minute (2)
+		"2000-12-31T23:59:60.123Z", // invalid second (1)
+		"2000-12-31T23:59:XX.123Z", // invalid second (2)
+		"2000-12-31T23:59:59.XXXZ", // invalid millis
+		"1999-01-01 23:45:00.123Z", // missing T separator
+		"1999 01-01T23:45:00.123Z", // missing date separator (1)
+		"1999-01 01T23:45:00.123Z", // missing date separator (2)
+		"1999-01-01T23 45:00.123Z", // missing time separator (1)
+		"1999-01-01T23:45 00.123Z", // missing time separator (2)
+		"1999-01-01T23:45:00.123 ", // missing timezone
+		"1999-01-01t23:45:00.123Z", // lowercase T
+		"1999-01-01T23:45:00.123z", // lowercase Z
 	} {
 		t.Run(input, func(t *testing.T) {
 			ts, err := time.Parse(time.RFC3339Nano, input)
@@ -113,12 +199,6 @@ func BenchmarkParse(b *testing.B) {
 	}
 }
 
-func BenchmarkParseInvalid(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		Parse("2006-01-02T15:04:05X")
-	}
-}
-
 func BenchmarkParseMilliseconds(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		Parse("2006-01-02T15:04:05.123Z")
@@ -134,5 +214,11 @@ func BenchmarkParseMicroseconds(b *testing.B) {
 func BenchmarkParseNanoseconds(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		Parse("2006-01-02T15:04:05.123456789Z")
+	}
+}
+
+func BenchmarkParseInvalid(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Parse("2006-01-02T15:04:05X")
 	}
 }

--- a/iso8601/parse_test.go
+++ b/iso8601/parse_test.go
@@ -176,6 +176,7 @@ func TestParseInvalid(t *testing.T) {
 		"1999-01 01T23:45:00.123Z", // missing date separator (2)
 		"1999-01-01T23 45:00.123Z", // missing time separator (1)
 		"1999-01-01T23:45 00.123Z", // missing time separator (2)
+		"1999-01-01T23:45:00 123Z", // missing time separator (3)
 		"1999-01-01T23:45:00.123 ", // missing timezone
 		"1999-01-01t23:45:00.123Z", // lowercase T
 		"1999-01-01T23:45:00.123z", // lowercase Z

--- a/iso8601/parse_test.go
+++ b/iso8601/parse_test.go
@@ -37,11 +37,27 @@ func TestParse(t *testing.T) {
 		})
 	}
 
-	// Check all ~3.7M YYYY-MM-DD dates
+	// Check ~4M YYYY-MM-DD dates.
 	for year := 0; year <= 9999; year++ {
-		for month := 1; month <= 12; month++ {
-			for day := 1; day <= 31; day++ {
+		for month := 0; month <= 13; month++ {
+			for day := 0; day <= 32; day++ {
 				input := fmt.Sprintf("%04d-%02d-%02dT00:00:00Z", year, month, day)
+				expect, expectErr := time.Parse(time.RFC3339Nano, input)
+				actual, actualErr := Parse(input)
+				if (expectErr != nil) != (actualErr != nil) {
+					t.Errorf("unexpected error for %v: %v vs. %v expected", input, actualErr, expectErr)
+				} else if !actual.Equal(expect) {
+					t.Errorf("unexpected time for %v: %v vs. %v expected", input, actual, expect)
+				}
+			}
+		}
+	}
+
+	// Check all ~1M HH:MM:SS times.
+	for hour := 0; hour < 100; hour++ {
+		for minute := 0; minute < 100; minute++ {
+			for second := 0; second < 100; second++ {
+				input := fmt.Sprintf("2000-01-01T%02d-%02d-%02dZ", hour, minute, second)
 				expect, expectErr := time.Parse(time.RFC3339Nano, input)
 				actual, actualErr := Parse(input)
 				if (expectErr != nil) != (actualErr != nil) {
@@ -65,7 +81,9 @@ func TestParseInvalid(t *testing.T) {
 		"2021-09-31T00:00:00Z", // 30 days in month
 		"2021-11-31T00:00:00Z", // 30 days in month
 		"2000-13-01T00:00:00Z", // invalid month
+		"2000-00-01T00:00:00Z", // invalid month
 		"2000-12-32T00:00:00Z", // invalid day
+		"2000-12-00T00:00:00Z", // invalid day
 		"2000-12-31T24:00:00Z", // invalid hour
 		"2000-12-31T23:60:00Z", // invalid minute
 		"2000-12-31T23:59:60Z", // invalid second

--- a/iso8601/parse_test.go
+++ b/iso8601/parse_test.go
@@ -7,11 +7,26 @@ import (
 
 func TestParse(t *testing.T) {
 	for _, input := range []string{
+		// Fast path
 		"1987-12-16T23:45:12Z",
 		"2006-01-02T15:04:05Z",
+		"2020-02-29T23:59:59Z", // leap year
+		"0000-01-01T00:00:00Z",
+		"9999-12-31T23:59:59Z",
+
+		// Slow path
+		"2006-01-02T15:04:05+00:00",
 		"2006-01-02T15:04:05.123Z",
+		"2006-01-02T15:04:05.123+00:00",
 		"2006-01-02T15:04:05.123456Z",
 		"2006-01-02T15:04:05.123456789Z",
+
+		// FIXME:
+		// "2021-02-29T00:00:00Z", // not a leap year
+		// "2021-04-31T00:00:00Z", // 30 days in month
+		// "2021-06-31T00:00:00Z", // 30 days in month
+		// "2021-09-31T00:00:00Z", // 30 days in month
+		// "2021-11-31T00:00:00Z", // 30 days in month
 	} {
 		t.Run(input, func(t *testing.T) {
 			expect, err := time.Parse(time.RFC3339Nano, input)

--- a/iso8601/parse_test.go
+++ b/iso8601/parse_test.go
@@ -100,9 +100,7 @@ func TestParseInvalid(t *testing.T) {
 				t.Fatalf("expected time.Parse('%s') error, got %v", input, ts)
 			}
 			ts, actualErr := Parse(input)
-			if actualErr == nil {
-				t.Fatalf("expected Parse('%s') error %v, got %v", input, err, ts)
-			} else if err.Error() != actualErr.Error() {
+			if (err != nil) != (actualErr != nil) {
 				t.Fatalf("expected Parse('%s') error %v, got %v", input, err, actualErr)
 			}
 		})

--- a/iso8601/parse_test.go
+++ b/iso8601/parse_test.go
@@ -39,8 +39,10 @@ func TestParse(t *testing.T) {
 
 func TestParseInvalid(t *testing.T) {
 	for _, input := range []string{
-		"1900-02-29T00:00:00Z", // not a leap year
-		"2021-02-29T00:00:00Z", // not a leap year
+		"1900-02-29T00:00:00Z", // 28 days in month (not a leap year)
+		"2021-02-29T00:00:00Z", // 28 days in month (not a leap year)
+		"2021-02-30T00:00:00Z", // 28 days in month
+		"2021-02-31T00:00:00Z", // 28 days in month
 		"2021-04-31T00:00:00Z", // 30 days in month
 		"2021-06-31T00:00:00Z", // 30 days in month
 		"2021-09-31T00:00:00Z", // 30 days in month

--- a/iso8601/parse_test.go
+++ b/iso8601/parse_test.go
@@ -1,0 +1,52 @@
+package iso8601
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParse(t *testing.T) {
+	for _, input := range []string{
+		"2006-01-02T15:04:05Z",
+		"2006-01-02T15:04:05.123Z",
+		"2006-01-02T15:04:05.123456Z",
+		"2006-01-02T15:04:05.123456789Z",
+	} {
+		t.Run(input, func(t *testing.T) {
+			expect, err := time.Parse(time.RFC3339Nano, input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			actual, err := Parse(input)
+			if err != nil {
+				t.Error(err)
+			} else if !actual.Equal(expect) {
+				t.Errorf("unexpected time: %v vs expected %v", actual, expect)
+			}
+		})
+	}
+}
+
+func BenchmarkParseSeconds(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Parse("2006-01-02T15:04:05Z")
+	}
+}
+
+func BenchmarkParseMilliseconds(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Parse("2006-01-02T15:04:05.123Z")
+	}
+}
+
+func BenchmarkParseMicroseconds(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Parse("2006-01-02T15:04:05.123456Z")
+	}
+}
+
+func BenchmarkParseNanoseconds(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Parse("2006-01-02T15:04:05.123456789Z")
+	}
+}

--- a/json/decode.go
+++ b/json/decode.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 	"time"
 	"unsafe"
+
+	"github.com/segmentio/encoding/iso8601"
 )
 
 func (d decoder) decodeNull(b []byte, p unsafe.Pointer) ([]byte, error) {
@@ -486,7 +488,7 @@ func (d decoder) decodeTime(b []byte, p unsafe.Pointer) ([]byte, error) {
 
 	s := b[1:i] // trim quotes
 
-	v, err := time.Parse(time.RFC3339Nano, *(*string)(unsafe.Pointer(&s)))
+	v, err := iso8601.Parse(*(*string)(unsafe.Pointer(&s)))
 	if err != nil {
 		return d.inputError(b, timeType)
 	}


### PR DESCRIPTION
I've added a new `iso8601.Parse` function with fast paths for strings of the form `YYYY-MM-DDTHH:MM:SSZ` and`YYYY-MM-DDTHH:MM:SS.MMMZ`. If the input string isn't one of these forms, it defers to `time.Parse(time.RFC3339Nano, str)`.

It's a good deal faster than `time.Parse` with valid/invalid 20/24 byte inputs:

```
name                 old time/op    new time/op    delta
Parse-4                 218ns ± 4%      21ns ± 1%   -90.49%  (p=0.008 n=5+5)
ParseMilliseconds-4     253ns ± 0%      22ns ± 0%   -91.24%  (p=0.016 n=4+5)
ParseMicroseconds-4     256ns ± 0%     260ns ± 0%    +1.60%  (p=0.008 n=5+5)
ParseNanoseconds-4      261ns ± 0%     264ns ± 0%    +0.90%  (p=0.008 n=5+5)
ParseInvalid-4          242ns ± 0%       5ns ± 0%   -97.90%  (p=0.008 n=5+5)

name                 old alloc/op   new alloc/op   delta
Parse-4                 0.00B          0.00B           ~     (all equal)
ParseMilliseconds-4     0.00B          0.00B           ~     (all equal)
ParseMicroseconds-4     0.00B          0.00B           ~     (all equal)
ParseNanoseconds-4      0.00B          0.00B           ~     (all equal)
ParseInvalid-4          80.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)
```

I've only added the two special cases given how common these forms are. It wouldn't be too difficult to add additional fast paths for the microseconds and nanosecond variants.