### PR TITLE
iso8601.Parse() timezone fix

### DIFF
--- a/iso8601/parse.go
+++ b/iso8601/parse.go
@@ -52,7 +52,7 @@ func Parse(input string) (time.Time, error) {
 		}
 
 		unixSeconds := int64(daysSinceEpoch(year, month, day))*86400 + int64(hour*3600+minute*60+second)
-		return time.Unix(unixSeconds, 0), nil
+		return time.Unix(unixSeconds, 0).UTC(), nil
 
 	case 24: // YYYY-MM-DDTHH:MM:SS.MMMZ
 		t1 := binary.LittleEndian.Uint64(b)
@@ -89,7 +89,7 @@ func Parse(input string) (time.Time, error) {
 		}
 
 		unixSeconds := int64(daysSinceEpoch(year, month, day))*86400 + int64(hour*3600+minute*60+second)
-		return time.Unix(unixSeconds, int64(millis*1e6)), nil
+		return time.Unix(unixSeconds, int64(millis*1e6)).UTC(), nil
 
 	default:
 		return time.Parse(time.RFC3339Nano, input)

--- a/iso8601/parse_test.go
+++ b/iso8601/parse_test.go
@@ -42,6 +42,8 @@ func TestParse(t *testing.T) {
 				t.Error(err)
 			} else if !actual.Equal(expect) {
 				t.Errorf("unexpected time: %v vs expected %v", actual, expect)
+			} else if actual.Location().String() != expect.Location().String() {
+				t.Errorf("unexpected timezone: %v vs expected %v", actual.Location().String(), expect.Location().String())
 			}
 		})
 	}


### PR DESCRIPTION
This fixes a bug introduced by https://github.com/segmentio/encoding/pull/82. `time.Unix()` attaches the local timezone. This wasn't caught by the unit tests as `time.Equal()` ignores the timezone.