### PR TITLE
fix issue 84

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - checkout
       - run: go mod download
-      - run: make test
+      - run: make test -j8
 
   benchmark:
     docker:

--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,12 @@ go-fuzz-corpus := ${GOPATH}/src/github.com/dvyukov/go-fuzz-corpus
 go-fuzz-dep := ${GOPATH}/src/github.com/dvyukov/go-fuzz/go-fuzz-dep
 
 test:
-	go test -v -cover ./ascii
-	go test -v -cover ./json
-	go test -v -cover ./proto
-	go test -v -cover -tags go1.15 ./json
+	go test -v -cover -race ./ascii
+	go test -v -cover -race ./json
+	go test -v -cover -race ./json/bugs
+	go test -v -cover -race ./proto
+	go test -v -cover -race -tags go1.17 ./json
 	go test -v -cover ./iso8601
-	go run ./json/bugs/issue11/main.go
-	go run ./json/bugs/issue18/main.go
 
 $(benchstat):
 	GO111MODULE=off go get -u golang.org/x/perf/cmd/benchstat

--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,25 @@ go-fuzz-build := ${GOPATH}/bin/go-fuzz-build
 go-fuzz-corpus := ${GOPATH}/src/github.com/dvyukov/go-fuzz-corpus
 go-fuzz-dep := ${GOPATH}/src/github.com/dvyukov/go-fuzz/go-fuzz-dep
 
-test:
-	go test -v -cover -race ./ascii
-	go test -v -cover -race ./json
-	go test -v -cover -race ./json/bugs
-	go test -v -cover -race ./proto
-	go test -v -cover -race -tags go1.17 ./json
-	go test -v -cover ./iso8601
+test: test-ascii test-json test-json-bugs test-json-1.17 test-proto test-iso8601
+
+test-ascii:
+	go test -cover -race ./ascii
+
+test-json:
+	go test -cover -race ./json
+
+test-json-bugs:
+	go test -cover -race ./json/bugs/...
+
+test-json-1.17:
+	go test -cover -race -tags go1.17 ./json
+
+test-proto:
+	go test -cover -race ./proto
+
+test-iso8601:
+	go test -cover -race ./iso8601
 
 $(benchstat):
 	GO111MODULE=off go get -u golang.org/x/perf/cmd/benchstat

--- a/ascii/ascii.go
+++ b/ascii/ascii.go
@@ -35,22 +35,18 @@ const (
 	hasMoreConstR32 = hasMoreConstL32 * 128
 )
 
-//go:nosplit
 func hasLess64(x, n uint64) bool {
 	return ((x - (hasLessConstL64 * n)) & ^x & hasLessConstR64) != 0
 }
 
-//go:nosplit
 func hasLess32(x, n uint32) bool {
 	return ((x - (hasLessConstL32 * n)) & ^x & hasLessConstR32) != 0
 }
 
-//go:nosplit
 func hasMore64(x, n uint64) bool {
 	return (((x + (hasMoreConstL64 * (127 - n))) | x) & hasMoreConstR64) != 0
 }
 
-//go:nosplit
 func hasMore32(x, n uint32) bool {
 	return (((x + (hasMoreConstL32 * (127 - n))) | x) & hasMoreConstR32) != 0
 }

--- a/ascii/valid_print.go
+++ b/ascii/valid_print.go
@@ -28,6 +28,9 @@ func ValidPrintString(s string) bool {
 			if asm.validPrintAVX2((*byte)(p), n) == 0 {
 				return false
 			}
+			if (n % 16) == 0 {
+				return true
+			}
 			k := (n / 16) * 16
 			p = unsafe.Pointer(uintptr(p) + k)
 			n -= k

--- a/internal/runtime_reflect/map.go
+++ b/internal/runtime_reflect/map.go
@@ -16,12 +16,12 @@ func Assign(typ, dst, src unsafe.Pointer) {
 	typedmemmove(typ, dst, src)
 }
 
-func MapAssign(t, m, k unsafe.Pointer) uintptr {
-	return uintptr(mapassign(t, m, k))
+func MapAssign(t, m, k unsafe.Pointer) unsafe.Pointer {
+	return mapassign(t, m, k)
 }
 
-func MakeMap(t unsafe.Pointer, cap int) uintptr {
-	return uintptr(makemap(t, cap))
+func MakeMap(t unsafe.Pointer, cap int) unsafe.Pointer {
+	return makemap(t, cap)
 }
 
 type MapIter struct{ hiter }
@@ -45,9 +45,9 @@ func (it *MapIter) HasNext() bool {
 	return it.key != nil
 }
 
-func (it *MapIter) Key() uintptr { return uintptr(it.key) }
+func (it *MapIter) Key() unsafe.Pointer { return it.key }
 
-func (it *MapIter) Value() uintptr { return uintptr(it.value) }
+func (it *MapIter) Value() unsafe.Pointer { return it.value }
 
 // copied from src/runtime/map.go, all pointer types replaced with
 // unsafe.Pointer.

--- a/internal/runtime_reflect/slice.go
+++ b/internal/runtime_reflect/slice.go
@@ -20,8 +20,8 @@ func (s *Slice) SetLen(n int) {
 	s.len = n
 }
 
-func (s *Slice) Index(i int, elemSize uintptr) uintptr {
-	return uintptr(s.data) + (uintptr(i) * elemSize)
+func (s *Slice) Index(i int, elemSize uintptr) unsafe.Pointer {
+	return unsafe.Pointer(uintptr(s.data) + (uintptr(i) * elemSize))
 }
 
 func MakeSlice(elemType unsafe.Pointer, len, cap int) Slice {

--- a/json/bugs/issue11/main.go
+++ b/json/bugs/issue11/main.go
@@ -1,22 +1,3 @@
 package main
 
-import (
-	"fmt"
-	"log"
-
-	"github.com/segmentio/encoding/json"
-)
-
-func main() {
-	m := map[string]map[string]interface{}{
-		"outerkey": {
-			"innerkey": "innervalue",
-		},
-	}
-
-	b, err := json.Marshal(m)
-	if err != nil {
-		log.Fatal(err)
-	}
-	fmt.Println(string(b))
-}
+func main() {}

--- a/json/bugs/issue11/main_test.go
+++ b/json/bugs/issue11/main_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/segmentio/encoding/json"
+)
+
+func TestIssue11(t *testing.T) {
+	m := map[string]map[string]interface{}{
+		"outerkey": {
+			"innerkey": "innervalue",
+		},
+	}
+
+	b, err := json.Marshal(m)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(string(b))
+}

--- a/json/bugs/issue18/main.go
+++ b/json/bugs/issue18/main.go
@@ -1,22 +1,4 @@
 package main
 
-import (
-	"bytes"
-	"fmt"
-
-	"github.com/segmentio/encoding/json"
-)
-
 func main() {
-	b := []byte(`{
-	"userId": "blah",
-	}`)
-
-	d := json.NewDecoder(bytes.NewReader(b))
-
-	var a struct {
-		UserId string `json:"userId"`
-	}
-	fmt.Println(d.Decode(&a))
-	fmt.Println(a)
 }

--- a/json/bugs/issue18/main_test.go
+++ b/json/bugs/issue18/main_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/segmentio/encoding/json"
+)
+
+func TestIssue18(t *testing.T) {
+	b := []byte(`{
+	"userId": "blah",
+	}`)
+
+	d := json.NewDecoder(bytes.NewReader(b))
+
+	var a struct {
+		UserId string `json:"userId"`
+	}
+	fmt.Println(d.Decode(&a))
+	fmt.Println(a)
+}

--- a/json/bugs/issue84/main.go
+++ b/json/bugs/issue84/main.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}

--- a/json/bugs/issue84/main_test.go
+++ b/json/bugs/issue84/main_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/segmentio/encoding/json"
+)
+
+type Foo struct {
+	Source struct {
+		Table string
+	}
+}
+
+func TestUnmarshal(t *testing.T) {
+	input := []byte(`{"source": {"table": "1234567"}}`)
+	r := &Foo{}
+	json.Unmarshal(input, r)
+}

--- a/proto/map.go
+++ b/proto/map.go
@@ -50,8 +50,8 @@ func mapSizeFuncOf(t reflect.Type, f *mapField) sizeFunc {
 		defer m.Done()
 
 		for m.Init(pointer(t), p); m.HasNext(); m.Next() {
-			keySize := f.keyCodec.size(unsafe.Pointer(m.Key()), wantzero)
-			valSize := f.valCodec.size(unsafe.Pointer(m.Value()), wantzero)
+			keySize := f.keyCodec.size(m.Key(), wantzero)
+			valSize := f.valCodec.size(m.Value(), wantzero)
 
 			if keySize > 0 {
 				n += keyTagSize + keySize
@@ -105,8 +105,8 @@ func mapEncodeFuncOf(t reflect.Type, f *mapField) encodeFunc {
 		defer m.Done()
 
 		for m.Init(pointer(t), p); m.HasNext(); m.Next() {
-			key := unsafe.Pointer(m.Key())
-			val := unsafe.Pointer(m.Value())
+			key := m.Key()
+			val := m.Value()
 
 			keySize := f.keyCodec.size(key, wantzero)
 			valSize := f.valCodec.size(val, wantzero)
@@ -220,7 +220,7 @@ func mapDecodeFuncOf(t reflect.Type, f *mapField, seen map[reflect.Type]*codec) 
 	return func(b []byte, p unsafe.Pointer, _ flags) (int, error) {
 		m := (*unsafe.Pointer)(p)
 		if *m == nil {
-			*m = unsafe.Pointer(MakeMap(mtype, 10))
+			*m = MakeMap(mtype, 10)
 		}
 		if len(b) == 0 {
 			return 0, nil
@@ -233,7 +233,7 @@ func mapDecodeFuncOf(t reflect.Type, f *mapField, seen map[reflect.Type]*codec) 
 
 		n, err := structCodec.decode(b, s, noflags)
 		if err == nil {
-			v := unsafe.Pointer(MapAssign(mtype, *m, s))
+			v := MapAssign(mtype, *m, s)
 			Assign(vtype, v, unsafe.Pointer(uintptr(s)+valueOffset))
 		}
 

--- a/proto/slice.go
+++ b/proto/slice.go
@@ -41,7 +41,7 @@ func sliceSizeFuncOf(t reflect.Type, r *repeatedField) sizeFunc {
 
 		if v := (*Slice)(p); v != nil {
 			for i := 0; i < v.Len(); i++ {
-				elem := unsafe.Pointer(v.Index(i, elemSize))
+				elem := v.Index(i, elemSize)
 				size := r.codec.size(elem, wantzero)
 				n += tagSize + size
 				if r.embedded {
@@ -64,7 +64,7 @@ func sliceEncodeFuncOf(t reflect.Type, r *repeatedField) encodeFunc {
 
 		if s := (*Slice)(p); s != nil {
 			for i := 0; i < s.Len(); i++ {
-				elem := unsafe.Pointer(s.Index(i, elemSize))
+				elem := s.Index(i, elemSize)
 				size := r.codec.size(elem, wantzero)
 
 				n := copy(b[offset:], tagData)
@@ -108,7 +108,7 @@ func sliceDecodeFuncOf(t reflect.Type, r *repeatedField) decodeFunc {
 			*s = growSlice(elemType, s)
 		}
 
-		n, err := r.codec.decode(b, unsafe.Pointer(s.Index(i, elemSize)), noflags)
+		n, err := r.codec.decode(b, s.Index(i, elemSize), noflags)
 		if err == nil {
 			s.SetLen(i + 1)
 		}


### PR DESCRIPTION
Fixes #84 

This PR modifies the functions in the `ascii` package to prevent pointers being advanced beyond the end of the memory areas they started in.

Technically, we were never dereferencing pointers with addresses beyond the allocated areas, but Go makes it invalid to simply have pointers that address unallocated memory. To my understanding, this is done to prevent exposing out-of-bounds pointers to the GC, which could mistakenly create references to objects that shouldn't have any, or potentially cause runtime errors if the GC finds pointers that aren't mapping to any allocated areas.

I believe that an alternative solution could have been to use `//go:nosplit` on the functions, which should prevent these "out-of-bounds" pointers from being seen by the GC, tho I haven't found enough literature on the subject to feel confident enough in that assumption.

Thanks @aaron42net for reporting the issue!