### PR TITLE
json: accept ; in json field tag

### DIFF
--- a/json/codec.go
+++ b/json/codec.go
@@ -844,7 +844,7 @@ func isValidTag(s string) bool {
 	}
 	for _, c := range s {
 		switch {
-		case strings.ContainsRune("!#$%&()*+-./:<=>?@[]^_{|}~ ", c):
+		case strings.ContainsRune("!#$%&()*+-./:;<=>?@[]^_{|}~ ", c):
 			// Backslash and quote chars are reserved, but
 			// otherwise any punctuation chars are allowed
 			// in a tag name.

--- a/json/golang_tagkey_test.go
+++ b/json/golang_tagkey_test.go
@@ -41,7 +41,7 @@ type percentSlashTag struct {
 }
 
 type punctuationTag struct {
-	V string `json:"!#$%&()*+-./:<=>?@[]^_{|}~"` // https://golang.org/issue/3546
+	V string `json:"!#$%&()*+-./:;<=>?@[]^_{|}~"` // https://golang.org/issue/3546
 }
 
 type dashTag struct {
@@ -90,7 +90,7 @@ var structTagObjectKeyTests = []struct {
 	{badFormatTag{"Orfevre"}, "Orfevre", "Y"},
 	{badCodeTag{"Reliable Man"}, "Reliable Man", "Z"},
 	{percentSlashTag{"brut"}, "brut", "text/html%"},
-	{punctuationTag{"Union Rags"}, "Union Rags", "!#$%&()*+-./:<=>?@[]^_{|}~"},
+	{punctuationTag{"Union Rags"}, "Union Rags", "!#$%&()*+-./:;<=>?@[]^_{|}~"},
 	{spaceTag{"Perreddu"}, "Perreddu", "With space"},
 	{unicodeTag{"Loukanikos"}, "Loukanikos", "Ελλάδα"},
 }


### PR DESCRIPTION
Accept ; in `json` field tag to match the behavior of Go 1.16.

https://go-review.googlesource.com/c/go/+/234818/4/src/encoding/json/encode.go

Fixes #86