### PR TITLE
fix(json): improve handling of omitempty with embedded pointers

### DIFF
--- a/json/codec.go
+++ b/json/codec.go
@@ -677,7 +677,9 @@ func appendStructFields(fields []structField, t reflect.Type, offset uintptr, se
 
 		if embfield.pointer {
 			subfield.codec = constructEmbeddedStructPointerCodec(embfield.subtype.typ, embfield.unexported, subfield.offset, subfield.codec)
+			subfield.ptrOffset = subfield.offset
 			subfield.offset = embfield.offset
+			subfield.ptr = true
 		} else {
 			subfield.offset += embfield.offset
 		}
@@ -931,7 +933,6 @@ type structType struct {
 	fieldsIndex map[string]*structField
 	ficaseIndex map[string]*structField
 	typ         reflect.Type
-	inlined     bool
 }
 
 type structField struct {
@@ -946,6 +947,8 @@ type structField struct {
 	typ       reflect.Type
 	zero      reflect.Value
 	index     int
+	ptr       bool
+	ptrOffset uintptr
 }
 
 func unmarshalTypeError(b []byte, t reflect.Type) error {

--- a/json/codec.go
+++ b/json/codec.go
@@ -677,7 +677,7 @@ func appendStructFields(fields []structField, t reflect.Type, offset uintptr, se
 
 		if embfield.pointer {
 			subfield.codec = constructEmbeddedStructPointerCodec(embfield.subtype.typ, embfield.unexported, subfield.offset, subfield.codec)
-			subfield.ptrOffset = subfield.offset
+			subfield.ptrOffset += subfield.offset
 			subfield.offset = embfield.offset
 			subfield.ptr = true
 		} else {

--- a/json/encode.go
+++ b/json/encode.go
@@ -767,8 +767,17 @@ func (e encoder) encodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 		f := &st.fields[i]
 		v := unsafe.Pointer(uintptr(p) + f.offset)
 
-		if f.omitempty && f.empty(v) {
-			continue
+		if f.omitempty {
+			if f.ptr {
+				v2 := *(*unsafe.Pointer)(v)
+				v3 := unsafe.Pointer(uintptr(v2) + f.ptrOffset)
+
+				if f.empty(v3) {
+					continue
+				}
+			} else if f.empty(v) {
+				continue
+			}
 		}
 
 		if escapeHTML {

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1606,32 +1606,99 @@ func (r *rawJsonString) UnmarshalJSON(b []byte) error {
 // as we were still looking to the parent struct to start and only using offsets
 // which resulted in the wrong values being extracted.
 func TestGithubIssue63(t *testing.T) {
-	expectedString := `{"my_field":"test","my_other_field":"testing","code":1}`
+	spec := []struct {
+		description string
+		input       func() interface{}
+		expected    string
+	}{
+		{
+			description: "original",
+			expected:    `{"my_field":"test","code":0}`,
+			input: func() interface{} {
+				type MyStruct struct {
+					MyField string `json:"my_field,omitempty"`
+				}
 
-	type MyStruct struct {
-		MyField      string `json:"my_field,omitempty"`
-		MyOtherField string `json:"my_other_field"`
-		MyEmptyField string `json:"my_empty_field,omitempty"`
-	}
+				type MyStruct2 struct {
+					*MyStruct
+					Code int `json:"code"`
+				}
 
-	type MyStruct2 struct {
-		*MyStruct
-		Code int `json:"code"`
-	}
-
-	input := MyStruct2{
-		MyStruct: &MyStruct{
-			MyField:      "test",
-			MyOtherField: "testing",
+				return MyStruct2{
+					MyStruct: &MyStruct{
+						MyField: "test",
+					},
+					Code: 0,
+				}
+			},
 		},
-		Code: 1,
+		{
+			description: "additional fields",
+			expected:    `{"my_field":"test","my_other_field":"testing","code":1}`,
+			input: func() interface{} {
+				type MyStruct struct {
+					MyField      string `json:"my_field,omitempty"`
+					MyOtherField string `json:"my_other_field"`
+					MyEmptyField string `json:"my_empty_field,omitempty"`
+				}
+
+				type MyStruct2 struct {
+					*MyStruct
+					Code int `json:"code"`
+				}
+
+				return MyStruct2{
+					MyStruct: &MyStruct{
+						MyField:      "test",
+						MyOtherField: "testing",
+					},
+					Code: 1,
+				}
+			},
+		},
+		{
+			description: "multiple embed levels",
+			expected:    `{"my_field":"test","my_other_field":"testing","code":1}`,
+			input: func() interface{} {
+				type MyStruct struct {
+					MyField      string `json:"my_field,omitempty"`
+					MyOtherField string `json:"my_other_field"`
+					MyEmptyField string `json:"my_empty_field,omitempty"`
+				}
+
+				type MyStruct2 struct {
+					*MyStruct
+					Code int `json:"code"`
+				}
+
+				type MyStruct3 struct {
+					*MyStruct2
+					A int `json:"a"`
+				}
+
+				return MyStruct3{
+					MyStruct2: &MyStruct2{
+						MyStruct: &MyStruct{
+							MyField:      "test",
+							MyOtherField: "testing",
+						},
+						Code: 1,
+					},
+					A: 2,
+				}
+			},
+		},
 	}
 
-	if b, err := Marshal(input); err != nil {
-		t.Error(err)
-	} else if string(b) != expectedString {
-		t.Errorf("got:      %s", string(b))
-		t.Errorf("expected: %s", expectedString)
+	for _, test := range spec {
+		t.Run(test.description, func(t *testing.T) {
+			if b, err := Marshal(test.input()); err != nil {
+				t.Error(err)
+			} else if string(b) != test.expected {
+				t.Errorf("got:      %s", string(b))
+				t.Errorf("expected: %s", test.expected)
+			}
+		})
 	}
 }
 

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1673,7 +1673,6 @@ func TestGithubIssue63(t *testing.T) {
 
 				type MyStruct3 struct {
 					*MyStruct2
-					A int `json:"a"`
 				}
 
 				return MyStruct3{
@@ -1684,7 +1683,6 @@ func TestGithubIssue63(t *testing.T) {
 						},
 						Code: 1,
 					},
-					A: 2,
 				}
 			},
 		},


### PR DESCRIPTION
This PR fixes #63 by improving the handling of embedded pointers. Not surprisingly, these are a tricky bunch to contend with, so I've included a few test cases to demonstrate the efficacy of this change, but would appreciate some feedback on additional test cases to include.

In short, when passing a value to the "is empty" func, previously we weren't following pointers properly when they were embedded since we failed to track the pointer addresses own offset. This fix still feels kinda janky to me, especially to someone not especially comfortable with dealing with pointers like this, but it seems to get the job done.