### PR TITLE
Improved struct field lookups

### DIFF
--- a/json/codec.go
+++ b/json/codec.go
@@ -474,9 +474,164 @@ func constructStructType(t reflect.Type, seen map[reflect.Type]*structType, canA
 				st.ficaseIndex[s] = f
 			}
 		}
+
+		st.lookup = buildLookup(st.fields)
 	}
 
 	return st
+}
+
+func buildLookup(f []structField) fieldLookup {
+	switch len(f) {
+	case 0:
+		return noFieldLookup
+	case 1:
+		return func(k []byte) *structField {
+			if string(k) == f[0].name {
+				return &f[0]
+			}
+			return nil
+		}
+	case 2:
+		return func(k []byte) *structField {
+			if string(k) == f[0].name {
+				return &f[0]
+			}
+			if string(k) == f[1].name {
+				return &f[1]
+			}
+			return nil
+		}
+	case 3:
+		return func(k []byte) *structField {
+			if string(k) == f[0].name {
+				return &f[0]
+			}
+			if string(k) == f[1].name {
+				return &f[1]
+			}
+			if string(k) == f[2].name {
+				return &f[2]
+			}
+			return nil
+		}
+	case 4:
+		return func(k []byte) *structField {
+			if string(k) == f[0].name {
+				return &f[0]
+			}
+			if string(k) == f[1].name {
+				return &f[1]
+			}
+			if string(k) == f[2].name {
+				return &f[2]
+			}
+			if string(k) == f[3].name {
+				return &f[3]
+			}
+			return nil
+		}
+	case 5:
+		return func(k []byte) *structField {
+			if string(k) == f[0].name {
+				return &f[0]
+			}
+			if string(k) == f[1].name {
+				return &f[1]
+			}
+			if string(k) == f[2].name {
+				return &f[2]
+			}
+			if string(k) == f[3].name {
+				return &f[3]
+			}
+			if string(k) == f[4].name {
+				return &f[4]
+			}
+			return nil
+		}
+	case 6:
+		return func(k []byte) *structField {
+			if string(k) == f[0].name {
+				return &f[0]
+			}
+			if string(k) == f[1].name {
+				return &f[1]
+			}
+			if string(k) == f[2].name {
+				return &f[2]
+			}
+			if string(k) == f[3].name {
+				return &f[3]
+			}
+			if string(k) == f[4].name {
+				return &f[4]
+			}
+			if string(k) == f[5].name {
+				return &f[5]
+			}
+			return nil
+		}
+	case 7:
+		return func(k []byte) *structField {
+			if string(k) == f[0].name {
+				return &f[0]
+			}
+			if string(k) == f[1].name {
+				return &f[1]
+			}
+			if string(k) == f[2].name {
+				return &f[2]
+			}
+			if string(k) == f[3].name {
+				return &f[3]
+			}
+			if string(k) == f[4].name {
+				return &f[4]
+			}
+			if string(k) == f[5].name {
+				return &f[5]
+			}
+			if string(k) == f[6].name {
+				return &f[6]
+			}
+			return nil
+		}
+	case 8:
+		return func(k []byte) *structField {
+			if string(k) == f[0].name {
+				return &f[0]
+			}
+			if string(k) == f[1].name {
+				return &f[1]
+			}
+			if string(k) == f[2].name {
+				return &f[2]
+			}
+			if string(k) == f[3].name {
+				return &f[3]
+			}
+			if string(k) == f[4].name {
+				return &f[4]
+			}
+			if string(k) == f[5].name {
+				return &f[5]
+			}
+			if string(k) == f[6].name {
+				return &f[6]
+			}
+			if string(k) == f[7].name {
+				return &f[7]
+			}
+			return nil
+		}
+	default:
+		return nil
+	}
+}
+
+func noFieldLookup([]byte) *structField {
+	return nil
 }
 
 func constructStructEncodeFunc(st *structType) encodeFunc {
@@ -930,9 +1085,12 @@ type structType struct {
 	fields      []structField
 	fieldsIndex map[string]*structField
 	ficaseIndex map[string]*structField
+	lookup      fieldLookup
 	typ         reflect.Type
 	inlined     bool
 }
+
+type fieldLookup func([]byte) *structField
 
 type structField struct {
 	codec     codec

--- a/json/decode.go
+++ b/json/decode.go
@@ -1184,7 +1184,12 @@ func (d decoder) decodeStruct(b []byte, p unsafe.Pointer, st *structType) ([]byt
 		}
 		b = skipSpaces(b[1:])
 
-		f := st.fieldsIndex[string(k)]
+		var f *structField
+		if st.lookup != nil {
+			f = st.lookup(k)
+		} else {
+			f = st.fieldsIndex[string(k)]
+		}
 
 		if f == nil && (d.flags&DontMatchCaseInsensitiveStructFields) == 0 {
 			key = appendToLower(buf[:0], k)


### PR DESCRIPTION
When decoding structs, we have the string key and need to lookup the associated decoder for that field: https://github.com/segmentio/encoding/blob/101dc9c5750213ca76cdac2fbc96d667f855555f/json/decode.go#L1187

For a small static set of keys, a general purpose `map[string]` is overkill. 

I was looking into perfect hashing but noticed that you can't beat a linear scan for small structs. When decoding small structs, the order of fields is often the same in the payloads you're deserializing, and there's a chance this pattern is picked up by the branch predictor.

```
name                             old time/op    new time/op    delta
Unmarshal/*json.codeResponse2-4    4.88ms ± 1%    4.58ms ± 1%  -6.23%  (p=0.000 n=19+16)

name                             old speed      new speed      delta
Unmarshal/*json.codeResponse2-4   398MB/s ± 1%   424MB/s ± 1%  +6.64%  (p=0.000 n=19+16)

name                             old alloc/op   new alloc/op   delta
Unmarshal/*json.codeResponse2-4    32.7kB ± 1%    31.2kB ± 3%  -4.68%  (p=0.000 n=17+16)

name                             old allocs/op  new allocs/op  delta
Unmarshal/*json.codeResponse2-4      57.0 ± 0%      54.0 ± 4%  -5.18%  (p=0.000 n=17+20)
```

I see a similar 5-6% improvements in other internal @segmentio benchmarks, though I suspect this is something that might help in most cases but be detrimental in others, so perhaps we make it opt-in or opt-out via a parse flag?