### PR TITLE
thrift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ go-fuzz-build := ${GOPATH}/bin/go-fuzz-build
 go-fuzz-corpus := ${GOPATH}/src/github.com/dvyukov/go-fuzz-corpus
 go-fuzz-dep := ${GOPATH}/src/github.com/dvyukov/go-fuzz/go-fuzz-dep
 
-test: test-ascii test-json test-json-bugs test-json-1.17 test-proto test-iso8601
+test: test-ascii test-json test-json-bugs test-json-1.17 test-proto test-iso8601 test-thrift
 
 test-ascii:
 	go test -cover -race ./ascii
@@ -29,6 +29,9 @@ test-proto:
 
 test-iso8601:
 	go test -cover -race ./iso8601
+
+test-thrift:
+	go test -cover -race ./thrift
 
 $(benchstat):
 	GO111MODULE=off go get -u golang.org/x/perf/cmd/benchstat

--- a/thrift/binary.go
+++ b/thrift/binary.go
@@ -1,0 +1,362 @@
+package thrift
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math"
+)
+
+type BinaryProtocol struct {
+	NonStrict bool
+}
+
+func (p *BinaryProtocol) NewReader(r *bufio.Reader) Reader {
+	return p.NewBinaryReader(r)
+}
+
+func (p *BinaryProtocol) NewWriter(w *bufio.Writer) Writer {
+	return p.NewBinaryWriter(w)
+}
+
+func (p *BinaryProtocol) NewBinaryReader(r *bufio.Reader) *BinaryReader {
+	return &BinaryReader{r: r}
+}
+
+func (p *BinaryProtocol) NewBinaryWriter(w *bufio.Writer) *BinaryWriter {
+	return &BinaryWriter{p: p, w: w}
+}
+
+type BinaryReader struct {
+	r *bufio.Reader
+	b bytes.Buffer
+	l io.LimitedReader
+}
+
+func (r *BinaryReader) Read(b []byte) (int, error) {
+	return r.r.Read(b)
+}
+
+func (r *BinaryReader) ReadBool() (bool, error) {
+	v, err := r.readByte()
+	return v != 0, err
+}
+
+func (r *BinaryReader) ReadInt8() (int8, error) {
+	b, err := r.readByte()
+	return int8(b), err
+}
+
+func (r *BinaryReader) ReadInt16() (int16, error) {
+	b, err := r.r.Peek(2)
+	if len(b) < 2 {
+		return 0, dontExpectEOF(err)
+	}
+	v := int16(binary.BigEndian.Uint16(b))
+	r.r.Discard(2)
+	return v, nil
+}
+
+func (r *BinaryReader) ReadInt32() (int32, error) {
+	b, err := r.r.Peek(4)
+	if len(b) < 4 {
+		return 0, dontExpectEOF(err)
+	}
+	v := int32(binary.BigEndian.Uint32(b))
+	r.r.Discard(4)
+	return v, nil
+}
+
+func (r *BinaryReader) ReadInt64() (int64, error) {
+	b, err := r.r.Peek(8)
+	if len(b) < 8 {
+		return 0, dontExpectEOF(err)
+	}
+	v := int64(binary.BigEndian.Uint64(b))
+	r.r.Discard(8)
+	return v, nil
+}
+
+func (r *BinaryReader) ReadFloat64() (float64, error) {
+	b, err := r.r.Peek(8)
+	if len(b) < 8 {
+		return 0, dontExpectEOF(err)
+	}
+	v := math.Float64frombits(binary.BigEndian.Uint64(b))
+	r.r.Discard(8)
+	return v, nil
+}
+
+func (r *BinaryReader) ReadBytes() ([]byte, error) {
+	n, err := r.ReadLength()
+	if err != nil {
+		return nil, err
+	}
+	b, err := r.read(n)
+	return copyBytes(b), err
+}
+
+func (r *BinaryReader) ReadString() (string, error) {
+	n, err := r.ReadLength()
+	if err != nil {
+		return "", err
+	}
+	b, err := r.read(n)
+	return string(b), err
+}
+
+func (r *BinaryReader) ReadLength() (int, error) {
+	b, err := r.r.Peek(4)
+	if len(b) < 4 {
+		return 0, dontExpectEOF(err)
+	}
+	n := binary.BigEndian.Uint32(b)
+	if n > math.MaxInt32 {
+		return 0, fmt.Errorf("length out of range: %d", n)
+	}
+	r.r.Discard(4)
+	return int(n), nil
+}
+
+func (r *BinaryReader) ReadMessage() (Message, error) {
+	m := Message{}
+
+	b, err := r.r.Peek(4)
+	if len(b) < 4 {
+		return m, dontExpectEOF(err)
+	}
+
+	if (b[0] >> 7) == 0 { // non-strict
+		if m.Name, err = r.ReadString(); err != nil {
+			return m, err
+		}
+		t, err := r.ReadInt8()
+		if err != nil {
+			return m, err
+		}
+		m.Type = MessageType(t & 0x7)
+	} else {
+		m.Type = MessageType(b[3] & 0x7)
+		r.r.Discard(4)
+
+		if m.Name, err = r.ReadString(); err != nil {
+			return m, err
+		}
+	}
+
+	m.SeqID, err = r.ReadInt32()
+	return m, err
+}
+
+func (r *BinaryReader) ReadField() (Field, error) {
+	t, err := r.ReadInt8()
+	if err != nil {
+		return Field{}, err
+	}
+	i, err := r.ReadInt16()
+	if err != nil {
+		return Field{}, err
+	}
+	return Field{ID: i, Type: Type(t)}, nil
+}
+
+func (r *BinaryReader) ReadList() (List, error) {
+	t, err := r.ReadInt8()
+	if err != nil {
+		return List{}, err
+	}
+	n, err := r.ReadInt32()
+	if err != nil {
+		return List{}, err
+	}
+	return List{Size: n, Type: Type(t)}, nil
+}
+
+func (r *BinaryReader) ReadMap() (Map, error) {
+	k, err := r.readByte()
+	if err != nil {
+		return Map{}, dontExpectEOF(err)
+	}
+	v, err := r.readByte()
+	if err != nil {
+		return Map{}, dontExpectEOF(err)
+	}
+	n, err := r.ReadInt32()
+	if err != nil {
+		return Map{}, err
+	}
+	return Map{Size: n, Key: Type(k), Value: Type(v)}, nil
+}
+
+func (r *BinaryReader) readByte() (byte, error) {
+	return r.r.ReadByte()
+}
+
+func (r *BinaryReader) read(n int) ([]byte, error) {
+	r.b.Reset()
+
+	if b, _ := r.r.Peek(n); len(b) == n {
+		r.b.Write(b)
+		r.r.Discard(n)
+		return r.b.Bytes(), nil
+	}
+
+	r.l.R = r.r
+	r.l.N = int64(n)
+	_, err := r.b.ReadFrom(&r.l)
+	return r.b.Bytes(), err
+}
+
+type BinaryWriter struct {
+	p *BinaryProtocol
+	w *bufio.Writer
+	b [8]byte
+}
+
+func (w *BinaryWriter) Write(b []byte) (int, error) {
+	return w.w.Write(b)
+}
+
+func (w *BinaryWriter) WriteBool(v bool) error {
+	var b byte
+	if v {
+		b = 1
+	}
+	return w.w.WriteByte(b)
+}
+
+func (w *BinaryWriter) WriteInt8(v int8) error {
+	return w.w.WriteByte(byte(v))
+}
+
+func (w *BinaryWriter) WriteInt16(v int16) error {
+	binary.BigEndian.PutUint16(w.b[:2], uint16(v))
+	return w.write(w.b[:2])
+}
+
+func (w *BinaryWriter) WriteInt32(v int32) error {
+	binary.BigEndian.PutUint32(w.b[:4], uint32(v))
+	return w.write(w.b[:4])
+}
+
+func (w *BinaryWriter) WriteInt64(v int64) error {
+	binary.BigEndian.PutUint64(w.b[:8], uint64(v))
+	return w.write(w.b[:8])
+}
+
+func (w *BinaryWriter) WriteFloat64(v float64) error {
+	binary.BigEndian.PutUint64(w.b[:8], math.Float64bits(v))
+	return w.write(w.b[:8])
+}
+
+func (w *BinaryWriter) WriteBytes(v []byte) error {
+	if err := w.WriteLength(len(v)); err != nil {
+		return err
+	}
+	return w.write(v)
+}
+
+func (w *BinaryWriter) WriteString(v string) error {
+	if err := w.WriteLength(len(v)); err != nil {
+		return err
+	}
+	return w.writeString(v)
+}
+
+func (w *BinaryWriter) WriteLength(n int) error {
+	if n < 0 {
+		return fmt.Errorf("negative length cannot be encoded in thrift: %d", n)
+	}
+	if n > math.MaxInt32 {
+		return fmt.Errorf("length is too large to be encoded in thrift: %d", n)
+	}
+	return w.WriteInt32(int32(n))
+}
+
+func (w *BinaryWriter) WriteMessage(m Message) error {
+	if w.p.NonStrict {
+		if err := w.WriteString(m.Name); err != nil {
+			return err
+		}
+		if err := w.writeByte(byte(m.Type)); err != nil {
+			return err
+		}
+	} else {
+		w.b[0] = 1 << 7
+		w.b[1] = 0
+		w.b[2] = 0
+		w.b[3] = byte(m.Type) & 0x7
+		binary.BigEndian.PutUint32(w.b[4:], uint32(len(m.Name)))
+
+		if err := w.write(w.b[:8]); err != nil {
+			return err
+		}
+		if err := w.writeString(m.Name); err != nil {
+			return err
+		}
+	}
+	return w.WriteInt32(m.SeqID)
+}
+
+func (w *BinaryWriter) WriteField(f Field) error {
+	if err := w.writeByte(byte(f.Type)); err != nil {
+		return err
+	}
+	return w.WriteInt16(f.ID)
+}
+
+func (w *BinaryWriter) WriteList(l List) error {
+	if err := w.writeByte(byte(l.Type)); err != nil {
+		return err
+	}
+	return w.WriteInt32(l.Size)
+}
+
+func (w *BinaryWriter) WriteMap(m Map) error {
+	if err := w.writeByte(byte(m.Key)); err != nil {
+		return err
+	}
+	if err := w.writeByte(byte(m.Value)); err != nil {
+		return err
+	}
+	return w.WriteInt32(m.Size)
+}
+
+func (w *BinaryWriter) write(b []byte) error {
+	_, err := w.w.Write(b)
+	return err
+}
+
+func (w *BinaryWriter) writeString(s string) error {
+	_, err := w.w.WriteString(s)
+	return err
+}
+
+func (w *BinaryWriter) writeByte(b byte) error {
+	return w.w.WriteByte(b)
+}
+
+func dontExpectEOF(err error) error {
+	switch err {
+	case nil:
+		return nil
+	case io.EOF:
+		return io.ErrUnexpectedEOF
+	default:
+		return err
+	}
+}
+
+func copyBytes(b []byte) []byte {
+	c := make([]byte, len(b))
+	copy(c, b)
+	return c
+}
+
+var (
+	_ Protocol = (*BinaryProtocol)(nil)
+	_ Reader   = (*BinaryReader)(nil)
+	_ Writer   = (*BinaryWriter)(nil)
+)

--- a/thrift/binary.go
+++ b/thrift/binary.go
@@ -215,27 +215,15 @@ func (r *BinaryReader) ReadByte() (byte, error) {
 }
 
 func (r *BinaryReader) read(n int) ([]byte, error) {
-	r.b = r.b[:0]
-
-	switch x := r.r.(type) {
-	case *bufio.Reader:
-		if b, _ := x.Peek(n); len(b) == n {
-			r.b = append(r.b, b...)
-			x.Discard(n)
-			return r.b, nil
-		}
-	}
-
 	if cap(r.b) < n {
 		c := n
 		if c < 64 {
 			c = 64
 		}
-		r.b = make([]byte, c)
+		r.b = make([]byte, c)[:n]
 	} else {
 		r.b = r.b[:n]
 	}
-
 	_, err := io.ReadFull(r.r, r.b)
 	return r.b, dontExpectEOF(err)
 }

--- a/thrift/binary.go
+++ b/thrift/binary.go
@@ -17,16 +17,25 @@ type BinaryProtocol struct {
 }
 
 func (p *BinaryProtocol) NewReader(r io.Reader) Reader {
-	return &binaryReader{r: r}
+	return &binaryReader{p: p, r: r}
 }
 
 func (p *BinaryProtocol) NewWriter(w io.Writer) Writer {
 	return &binaryWriter{p: p, w: w}
 }
 
+func (p *BinaryProtocol) Features() Features {
+	return 0
+}
+
 type binaryReader struct {
+	p *BinaryProtocol
 	r io.Reader
 	b [8]byte
+}
+
+func (r *binaryReader) Protocol() Protocol {
+	return r.p
 }
 
 func (r *binaryReader) Reader() io.Reader {
@@ -210,6 +219,10 @@ type binaryWriter struct {
 	p *BinaryProtocol
 	b [8]byte
 	w io.Writer
+}
+
+func (w *binaryWriter) Protocol() Protocol {
+	return w.p
 }
 
 func (w *binaryWriter) Writer() io.Writer {

--- a/thrift/binary.go
+++ b/thrift/binary.go
@@ -9,6 +9,9 @@ import (
 	"math"
 )
 
+// BinaryProtocol is a Protocol implementation for the binary thrift protocol.
+//
+// https://github.com/apache/thrift/blob/master/doc/specs/thrift-binary-protocol.md
 type BinaryProtocol struct {
 	NonStrict bool
 }
@@ -29,6 +32,9 @@ func (p *BinaryProtocol) NewBinaryWriter(w io.Writer) *BinaryWriter {
 	return &BinaryWriter{p: p, w: w}
 }
 
+// BinaryReader is a Reader implementation for the binary thrift protocol.
+//
+// https://github.com/apache/thrift/blob/master/doc/specs/thrift-binary-protocol.md
 type BinaryReader struct {
 	r io.Reader
 	b []byte
@@ -234,6 +240,9 @@ func (r *BinaryReader) read(n int) ([]byte, error) {
 	return r.b, dontExpectEOF(err)
 }
 
+// BinaryWriter is a Writer implementation for the binary thrift protocol.
+//
+// https://github.com/apache/thrift/blob/master/doc/specs/thrift-binary-protocol.md
 type BinaryWriter struct {
 	p *BinaryProtocol
 	b [8]byte

--- a/thrift/compact.go
+++ b/thrift/compact.go
@@ -9,6 +9,9 @@ import (
 	"math"
 )
 
+// CompactProtocol is a Protocol implementation for the compact thrift protocol.
+//
+// https://github.com/apache/thrift/blob/master/doc/specs/thrift-compact-protocol.md#integer-encoding
 type CompactProtocol struct{}
 
 func (p *CompactProtocol) NewReader(r io.Reader) Reader {
@@ -27,6 +30,9 @@ func (p *CompactProtocol) NewCompactWriter(w io.Writer) *CompactWriter {
 	return &CompactWriter{binary: BinaryWriter{w: w}}
 }
 
+// CompactReader is a Reader implementation for the compact thrift protocol.
+//
+// https://github.com/apache/thrift/blob/master/doc/specs/thrift-compact-protocol.md#integer-encoding
 type CompactReader struct {
 	binary    BinaryReader
 	lastField Field
@@ -215,6 +221,9 @@ func (r *CompactReader) readVarint(typ string, min, max int64) (int64, error) {
 	return v, err
 }
 
+// CompactWriter is a Writer implementation for the compact thrift protocol.
+//
+// https://github.com/apache/thrift/blob/master/doc/specs/thrift-compact-protocol.md#integer-encoding
 type CompactWriter struct {
 	binary    BinaryWriter
 	varint    [binary.MaxVarintLen64]byte

--- a/thrift/compact.go
+++ b/thrift/compact.go
@@ -1,0 +1,308 @@
+package thrift
+
+import (
+	"bufio"
+	"encoding/binary"
+	"fmt"
+	"math"
+)
+
+type CompactProtocol struct{}
+
+func (p *CompactProtocol) NewReader(r *bufio.Reader) Reader {
+	return p.NewCompactReader(r)
+}
+
+func (p *CompactProtocol) NewWriter(w *bufio.Writer) Writer {
+	return p.NewCompactWriter(w)
+}
+
+func (p *CompactProtocol) NewCompactReader(r *bufio.Reader) *CompactReader {
+	return &CompactReader{binary: BinaryReader{r: r}}
+}
+
+func (p *CompactProtocol) NewCompactWriter(w *bufio.Writer) *CompactWriter {
+	return &CompactWriter{binary: BinaryWriter{w: w}}
+}
+
+type CompactReader struct {
+	binary    BinaryReader
+	lastField Field
+}
+
+func (r *CompactReader) Read(b []byte) (int, error) {
+	return r.binary.Read(b)
+}
+
+func (r *CompactReader) ReadBool() (bool, error) {
+	switch r.lastField.Type {
+	case TRUE:
+		r.lastField = Field{}
+		return true, nil
+	case FALSE:
+		r.lastField = Field{}
+		return false, nil
+	default:
+		return r.binary.ReadBool()
+	}
+}
+
+func (r *CompactReader) ReadInt8() (int8, error) {
+	return r.binary.ReadInt8()
+}
+
+func (r *CompactReader) ReadInt16() (int16, error) {
+	v, err := r.readVarint("int16", math.MinInt16, math.MaxInt16)
+	return int16(v), err
+}
+
+func (r *CompactReader) ReadInt32() (int32, error) {
+	v, err := r.readVarint("int32", math.MinInt32, math.MaxInt32)
+	return int32(v), err
+}
+
+func (r *CompactReader) ReadInt64() (int64, error) {
+	return r.readVarint("int64", math.MinInt64, math.MaxInt64)
+}
+
+func (r *CompactReader) ReadFloat64() (float64, error) {
+	return r.binary.ReadFloat64()
+}
+
+func (r *CompactReader) ReadBytes() ([]byte, error) {
+	n, err := r.ReadLength()
+	if err != nil {
+		return nil, err
+	}
+	b, err := r.binary.read(n)
+	return copyBytes(b), err
+}
+
+func (r *CompactReader) ReadString() (string, error) {
+	n, err := r.ReadLength()
+	if err != nil {
+		return "", err
+	}
+	b, err := r.binary.read(n)
+	return string(b), err
+}
+
+func (r *CompactReader) ReadLength() (int, error) {
+	n, err := r.readVarint("length", 0, math.MaxInt32)
+	if err != nil {
+		return 0, err
+	}
+	if n < 0 || n > math.MaxInt32 {
+		return 0, fmt.Errorf("length out of range: %d", n)
+	}
+	return int(n), nil
+}
+
+func (r *CompactReader) ReadMessage() (Message, error) {
+	m := Message{}
+
+	b0, err := r.binary.readByte()
+	if err != nil {
+		return m, dontExpectEOF(err)
+	}
+	if b0 != 0x82 {
+		return m, fmt.Errorf("invalid protocol id found when reading thrift message: %#x", b0)
+	}
+
+	b1, err := r.binary.readByte()
+	if err != nil {
+		return m, dontExpectEOF(err)
+	}
+
+	m.Type = MessageType(b1) & 0x7
+	m.SeqID, err = r.ReadInt32()
+	if err != nil {
+		return m, err
+	}
+	m.Name, err = r.ReadString()
+	return m, err
+}
+
+func (r *CompactReader) ReadField() (Field, error) {
+	f := Field{}
+	defer func() { r.lastField = f }()
+
+	b, err := r.binary.readByte()
+	if err != nil {
+		return f, dontExpectEOF(err)
+	}
+
+	if b == 0 { // stop field
+		return f, nil
+	}
+
+	if (b >> 4) != 0 {
+		f = Field{ID: int16(b>>4) + r.lastField.ID, Type: Type(b & 0xF)}
+	} else {
+		i, err := r.ReadInt16()
+		if err != nil {
+			return f, err
+		}
+		f = Field{ID: i, Type: Type(b)}
+	}
+
+	return f, nil
+}
+
+func (r *CompactReader) ReadList() (List, error) {
+	b, err := r.binary.readByte()
+	if err != nil {
+		return List{}, dontExpectEOF(err)
+	}
+	if (b >> 4) != 0xF {
+		return List{Size: int32(b >> 4), Type: Type(b & 0xF)}, nil
+	}
+	n, err := r.ReadInt32()
+	if err != nil {
+		return List{}, err
+	}
+	return List{Size: n, Type: Type(b & 0xF)}, nil
+}
+
+func (r *CompactReader) ReadMap() (Map, error) {
+	n, err := r.ReadInt32()
+	if err != nil {
+		return Map{}, err
+	}
+	if n == 0 { // empty map
+		return Map{}, nil
+	}
+	b, err := r.binary.readByte()
+	if err != nil {
+		return Map{}, dontExpectEOF(err)
+	}
+	return Map{Size: n, Key: Type(b >> 4), Value: Type(b & 0xF)}, nil
+}
+
+func (r *CompactReader) readVarint(typ string, min, max int64) (int64, error) {
+	v, err := binary.ReadVarint(r.binary.r)
+	if err == nil {
+		if v < min || v > max {
+			err = fmt.Errorf("%s varint out of range: %d not in [%d;%d]", typ, v, min, max)
+		}
+	}
+	return v, err
+}
+
+type CompactWriter struct {
+	binary    BinaryWriter
+	varint    [binary.MaxVarintLen64]byte
+	lastField Field
+}
+
+func (w *CompactWriter) Write(b []byte) (int, error) {
+	return w.binary.Write(b)
+}
+
+func (w *CompactWriter) WriteBool(v bool) error {
+	switch w.lastField.Type {
+	case TRUE, FALSE:
+		return nil // the value is already encoded in the type
+	default:
+		return w.binary.WriteBool(v)
+	}
+}
+
+func (w *CompactWriter) WriteInt8(v int8) error {
+	return w.binary.WriteInt8(v)
+}
+
+func (w *CompactWriter) WriteInt16(v int16) error {
+	return w.writeVarint(int64(v))
+}
+
+func (w *CompactWriter) WriteInt32(v int32) error {
+	return w.writeVarint(int64(v))
+}
+
+func (w *CompactWriter) WriteInt64(v int64) error {
+	return w.writeVarint(v)
+}
+
+func (w *CompactWriter) WriteFloat64(v float64) error {
+	return w.binary.WriteFloat64(v)
+}
+
+func (w *CompactWriter) WriteBytes(v []byte) error {
+	if err := w.WriteLength(len(v)); err != nil {
+		return err
+	}
+	return w.binary.write(v)
+}
+
+func (w *CompactWriter) WriteString(v string) error {
+	if err := w.WriteLength(len(v)); err != nil {
+		return err
+	}
+	return w.binary.writeString(v)
+}
+
+func (w *CompactWriter) WriteLength(n int) error {
+	if n < 0 {
+		return fmt.Errorf("negative length cannot be encoded in thrift: %d", n)
+	}
+	if n > math.MaxInt32 {
+		return fmt.Errorf("length is too large to be encoded in thrift: %d", n)
+	}
+	return w.writeVarint(int64(n))
+}
+
+func (w *CompactWriter) WriteMessage(m Message) error {
+	if err := w.binary.writeByte(0x82); err != nil {
+		return err
+	}
+	if err := w.binary.writeByte(byte(m.Type)); err != nil {
+		return err
+	}
+	if err := w.WriteInt32(m.SeqID); err != nil {
+		return err
+	}
+	return w.WriteString(m.Name)
+}
+
+func (w *CompactWriter) WriteField(f Field) error {
+	defer func() { w.lastField = f }()
+	if f.ID == 0 && f.Type == 0 { // stop field
+		return w.binary.writeByte(0)
+	}
+	if f.ID > w.lastField.ID && (f.ID-w.lastField.ID) <= 15 { // delta encoding
+		return w.binary.writeByte(byte((f.ID-w.lastField.ID)<<4) | byte(f.Type))
+	}
+	if err := w.WriteInt8(int8(f.Type)); err != nil {
+		return err
+	}
+	return w.WriteInt16(f.ID)
+}
+
+func (w *CompactWriter) WriteList(l List) error {
+	if l.Size <= 15 {
+		return w.binary.writeByte(byte(l.Size<<4) | byte(l.Type))
+	}
+	if err := w.binary.writeByte(0xF0 | byte(l.Type)); err != nil {
+		return err
+	}
+	return w.WriteInt32(l.Size)
+}
+
+func (w *CompactWriter) WriteMap(m Map) error {
+	if err := w.WriteInt32(m.Size); err != nil || m.Size == 0 {
+		return err
+	}
+	return w.binary.writeByte((byte(m.Key) << 4) | byte(m.Value))
+}
+
+func (w *CompactWriter) writeVarint(v int64) error {
+	n := binary.PutVarint(w.varint[:], v)
+	return w.binary.write(w.varint[:n])
+}
+
+var (
+	_ Protocol = (*CompactProtocol)(nil)
+	_ Reader   = (*CompactReader)(nil)
+	_ Writer   = (*CompactWriter)(nil)
+)

--- a/thrift/debug.go
+++ b/thrift/debug.go
@@ -1,0 +1,222 @@
+package thrift
+
+import (
+	"io"
+	"log"
+)
+
+func NewDebugReader(r Reader, l *log.Logger) Reader {
+	return &debugReader{
+		r: r,
+		l: l,
+	}
+}
+
+func NewDebugWriter(w Writer, l *log.Logger) Writer {
+	return &debugWriter{
+		w: w,
+		l: l,
+	}
+}
+
+type debugReader struct {
+	r Reader
+	l *log.Logger
+}
+
+func (d *debugReader) log(method string, res interface{}, err error) {
+	if err != nil {
+		d.l.Printf("(%T).%s() → ERROR: %v", d.r, method, err)
+	} else {
+		d.l.Printf("(%T).%s() → %#v", d.r, method, res)
+	}
+}
+
+func (d *debugReader) Reader() io.Reader {
+	return d.r.Reader()
+}
+
+func (d *debugReader) ReadBool() (bool, error) {
+	v, err := d.r.ReadBool()
+	d.log("ReadBool", v, err)
+	return v, err
+}
+
+func (d *debugReader) ReadInt8() (int8, error) {
+	v, err := d.r.ReadInt8()
+	d.log("ReadInt8", v, err)
+	return v, err
+}
+
+func (d *debugReader) ReadInt16() (int16, error) {
+	v, err := d.r.ReadInt16()
+	d.log("ReadInt16", v, err)
+	return v, err
+}
+
+func (d *debugReader) ReadInt32() (int32, error) {
+	v, err := d.r.ReadInt32()
+	d.log("ReadInt32", v, err)
+	return v, err
+}
+
+func (d *debugReader) ReadInt64() (int64, error) {
+	v, err := d.r.ReadInt64()
+	d.log("ReadInt64", v, err)
+	return v, err
+}
+
+func (d *debugReader) ReadFloat64() (float64, error) {
+	v, err := d.r.ReadFloat64()
+	d.log("ReadFloat64", v, err)
+	return v, err
+}
+
+func (d *debugReader) ReadBytes() ([]byte, error) {
+	v, err := d.r.ReadBytes()
+	d.log("ReadBytes", v, err)
+	return v, err
+}
+
+func (d *debugReader) ReadString() (string, error) {
+	v, err := d.r.ReadString()
+	d.log("ReadString", v, err)
+	return v, err
+}
+
+func (d *debugReader) ReadLength() (int, error) {
+	v, err := d.r.ReadLength()
+	d.log("ReadLength", v, err)
+	return v, err
+}
+
+func (d *debugReader) ReadMessage() (Message, error) {
+	v, err := d.r.ReadMessage()
+	d.log("ReadMessage", v, err)
+	return v, err
+}
+
+func (d *debugReader) ReadField() (Field, error) {
+	v, err := d.r.ReadField()
+	d.log("ReadField", v, err)
+	return v, err
+}
+
+func (d *debugReader) ReadList() (List, error) {
+	v, err := d.r.ReadList()
+	d.log("ReadList", v, err)
+	return v, err
+}
+
+func (d *debugReader) ReadSet() (Set, error) {
+	v, err := d.r.ReadSet()
+	d.log("ReadSet", v, err)
+	return v, err
+}
+
+func (d *debugReader) ReadMap() (Map, error) {
+	v, err := d.r.ReadMap()
+	d.log("ReadMap", v, err)
+	return v, err
+}
+
+type debugWriter struct {
+	w Writer
+	l *log.Logger
+}
+
+func (d *debugWriter) log(method string, arg interface{}, err error) {
+	if err != nil {
+		d.l.Printf("(%T).%s(%#v) → ERROR: %v", d.w, method, arg, err)
+	} else {
+		d.l.Printf("(%T).%s(%#v)", d.w, method, arg)
+	}
+}
+
+func (d *debugWriter) Writer() io.Writer {
+	return d.w.Writer()
+}
+
+func (d *debugWriter) WriteBool(v bool) error {
+	err := d.w.WriteBool(v)
+	d.log("WriteBool", v, err)
+	return err
+}
+
+func (d *debugWriter) WriteInt8(v int8) error {
+	err := d.w.WriteInt8(v)
+	d.log("WriteInt8", v, err)
+	return err
+}
+
+func (d *debugWriter) WriteInt16(v int16) error {
+	err := d.w.WriteInt16(v)
+	d.log("WriteInt16", v, err)
+	return err
+}
+
+func (d *debugWriter) WriteInt32(v int32) error {
+	err := d.w.WriteInt32(v)
+	d.log("WriteInt32", v, err)
+	return err
+}
+
+func (d *debugWriter) WriteInt64(v int64) error {
+	err := d.w.WriteInt64(v)
+	d.log("WriteInt64", v, err)
+	return err
+}
+
+func (d *debugWriter) WriteFloat64(v float64) error {
+	err := d.w.WriteFloat64(v)
+	d.log("WriteFloat64", v, err)
+	return err
+}
+
+func (d *debugWriter) WriteBytes(v []byte) error {
+	err := d.w.WriteBytes(v)
+	d.log("WriteBytes", v, err)
+	return err
+}
+
+func (d *debugWriter) WriteString(v string) error {
+	err := d.w.WriteString(v)
+	d.log("WriteString", v, err)
+	return err
+}
+
+func (d *debugWriter) WriteLength(n int) error {
+	err := d.w.WriteLength(n)
+	d.log("WriteLength", n, err)
+	return err
+}
+
+func (d *debugWriter) WriteMessage(m Message) error {
+	err := d.w.WriteMessage(m)
+	d.log("WriteMessage", m, err)
+	return err
+}
+
+func (d *debugWriter) WriteField(f Field) error {
+	err := d.w.WriteField(f)
+	d.log("WriteField", f, err)
+	return err
+}
+
+func (d *debugWriter) WriteList(l List) error {
+	err := d.w.WriteList(l)
+	d.log("WriteList", l, err)
+	return err
+}
+
+func (d *debugWriter) WriteSet(s Set) error {
+	err := d.w.WriteSet(s)
+	d.log("WriteSet", s, err)
+	return err
+}
+
+func (d *debugWriter) WriteMap(m Map) error {
+	err := d.w.WriteMap(m)
+	d.log("WriteMap", m, err)
+	return err
+}

--- a/thrift/debug.go
+++ b/thrift/debug.go
@@ -32,6 +32,10 @@ func (d *debugReader) log(method string, res interface{}, err error) {
 	}
 }
 
+func (d *debugReader) Protocol() Protocol {
+	return d.r.Protocol()
+}
+
 func (d *debugReader) Reader() io.Reader {
 	return d.r.Reader()
 }
@@ -131,6 +135,10 @@ func (d *debugWriter) log(method string, arg interface{}, err error) {
 	} else {
 		d.l.Printf("(%T).%s(%#v)", d.w, method, arg)
 	}
+}
+
+func (d *debugWriter) Protocol() Protocol {
+	return d.w.Protocol()
 }
 
 func (d *debugWriter) Writer() io.Writer {

--- a/thrift/decode.go
+++ b/thrift/decode.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"reflect"
 	"sync/atomic"
 )
@@ -579,7 +580,7 @@ func skipBinary(r Reader) error {
 	case *bufio.Reader:
 		_, err = x.Discard(int(n))
 	default:
-		_, err = io.CopyN(io.Discard, x, int64(n))
+		_, err = io.CopyN(ioutil.Discard, x, int64(n))
 	}
 	return err
 }

--- a/thrift/decode.go
+++ b/thrift/decode.go
@@ -448,7 +448,7 @@ func (dec *structDecoder) decode(r Reader, v reflect.Value, flags flags) error {
 	}
 
 	for i, required := range dec.required {
-		if mask := (required & seen[i]); mask != required {
+		if mask := required & seen[i]; mask != required {
 			index := bits.TrailingZeros64(mask)
 			field := &dec.fields[i/64+index]
 			return &MissingField{Field: Field{ID: field.id, Type: field.typ}}

--- a/thrift/decode.go
+++ b/thrift/decode.go
@@ -271,7 +271,7 @@ func decodeFuncSliceOf(t reflect.Type, seen decodeFuncCache) decodeFunc {
 
 		for i := 0; i < int(l.Size); i++ {
 			if err := dec(r, v.Index(i), flags); err != nil {
-				return with(dontExpectEOF(err), &decodeErrorList{list: l, index: i})
+				return with(dontExpectEOF(err), &decodeErrorList{cause: l, index: i})
 			}
 		}
 
@@ -326,10 +326,10 @@ func decodeFuncMapOf(t reflect.Type, seen decodeFuncCache) decodeFunc {
 
 		for i := 0; i < int(m.Size); i++ {
 			if err := decodeKey(r, tmpKey, flags); err != nil {
-				return with(dontExpectEOF(err), &decodeErrorMap{_map: m, index: i})
+				return with(dontExpectEOF(err), &decodeErrorMap{cause: m, index: i})
 			}
 			if err := decodeElem(r, tmpElem, flags); err != nil {
-				return with(dontExpectEOF(err), &decodeErrorMap{_map: m, index: i})
+				return with(dontExpectEOF(err), &decodeErrorMap{cause: m, index: i})
 			}
 			v.SetMapIndex(tmpKey, tmpElem)
 			tmpKey.Set(keyZero)
@@ -372,7 +372,7 @@ func decodeFuncMapAsSetOf(t reflect.Type, seen decodeFuncCache) decodeFunc {
 
 		for i := 0; i < int(s.Size); i++ {
 			if err := dec(r, tmp, flags); err != nil {
-				return with(dontExpectEOF(err), &decodeErrorSet{set: s, index: i})
+				return with(dontExpectEOF(err), &decodeErrorSet{cause: s, index: i})
 			}
 			v.SetMapIndex(tmp, elemZero)
 			tmp.Set(keyZero)
@@ -562,7 +562,7 @@ func readList(r Reader, f func(Reader, Type) error) error {
 
 	for i := 0; i < int(l.Size); i++ {
 		if err := f(r, l.Type); err != nil {
-			return with(dontExpectEOF(err), &decodeErrorList{list: l, index: i})
+			return with(dontExpectEOF(err), &decodeErrorList{cause: l, index: i})
 		}
 	}
 
@@ -577,7 +577,7 @@ func readSet(r Reader, f func(Reader, Type) error) error {
 
 	for i := 0; i < int(s.Size); i++ {
 		if err := f(r, s.Type); err != nil {
-			return with(dontExpectEOF(err), &decodeErrorSet{set: s, index: i})
+			return with(dontExpectEOF(err), &decodeErrorSet{cause: s, index: i})
 		}
 	}
 
@@ -592,7 +592,7 @@ func readMap(r Reader, f func(Reader, Type, Type) error) error {
 
 	for i := 0; i < int(m.Size); i++ {
 		if err := f(r, m.Key, m.Value); err != nil {
-			return with(dontExpectEOF(err), &decodeErrorMap{_map: m, index: i})
+			return with(dontExpectEOF(err), &decodeErrorMap{cause: m, index: i})
 		}
 	}
 
@@ -622,7 +622,7 @@ func readStruct(r Reader, f func(Reader, Field) error) error {
 		}
 
 		if err := f(r, x); err != nil {
-			return with(dontExpectEOF(err), &decodeErrorField{field: x})
+			return with(dontExpectEOF(err), &decodeErrorField{cause: x})
 		}
 
 		lastFieldID = x.ID

--- a/thrift/decode.go
+++ b/thrift/decode.go
@@ -401,12 +401,12 @@ func decodeFuncStructOf(t reflect.Type, seen decodeFuncCache) decodeFunc {
 	seen[t] = decode
 
 	fields := make([]structDecoderField, 0, t.NumField())
-	forEachStructField(t, nil, func(t reflect.Type, id int16, index []int) {
+	forEachStructField(t, nil, func(f structField) {
 		fields = append(fields, structDecoderField{
-			index:  index,
-			id:     id,
-			typ:    TypeOf(t),
-			decode: decodeFuncOf(t, seen),
+			index:  f.index,
+			id:     f.id,
+			typ:    TypeOf(f.typ),
+			decode: decodeFuncStructFieldOf(f, seen),
 		})
 	})
 
@@ -434,6 +434,18 @@ func decodeFuncStructOf(t reflect.Type, seen decodeFuncCache) decodeFunc {
 	}
 
 	return decode
+}
+
+func decodeFuncStructFieldOf(f structField, seen decodeFuncCache) decodeFunc {
+	if f.enum {
+		switch f.typ.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			return decodeInt32
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+			return decodeUint32
+		}
+	}
+	return decodeFuncOf(f.typ, seen)
 }
 
 func decodeFuncPtrOf(t reflect.Type, seen decodeFuncCache) decodeFunc {

--- a/thrift/decode.go
+++ b/thrift/decode.go
@@ -9,6 +9,11 @@ import (
 	"sync/atomic"
 )
 
+// Unmarshal deserializes the thrift data from b to v using to the protocol p.
+//
+// The function errors if the data in b does not match the type of v.
+//
+// The function panics if v cannot be converted to a thrift representation.
 func Unmarshal(p Protocol, b []byte, v interface{}) error {
 	br := bytes.NewReader(b)
 	pr := p.NewReader(br)

--- a/thrift/decode.go
+++ b/thrift/decode.go
@@ -41,7 +41,7 @@ func (d *Decoder) Decode(v interface{}) error {
 	t := reflect.TypeOf(v)
 	p := reflect.ValueOf(v)
 
-	if p.Kind() != reflect.Ptr {
+	if t.Kind() != reflect.Ptr {
 		panic("thrift.(*Decoder).Decode: expected pointer type but got " + t.String())
 	}
 

--- a/thrift/decode.go
+++ b/thrift/decode.go
@@ -1,0 +1,592 @@
+package thrift
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"reflect"
+	"sync/atomic"
+)
+
+func Unmarshal(p Protocol, b []byte, v interface{}) error {
+	br := bytes.NewReader(b)
+	pr := p.NewReader(br)
+
+	if err := NewDecoder(pr).Decode(v); err != nil {
+		return err
+	}
+
+	if n := br.Len(); n != 0 {
+		return fmt.Errorf("unexpected trailing bytes at the end of thrift input: %d", n)
+	}
+
+	return nil
+}
+
+type Decoder struct {
+	r Reader
+}
+
+func NewDecoder(r Reader) *Decoder {
+	return &Decoder{r: r}
+}
+
+func (d *Decoder) Decode(v interface{}) error {
+	t := reflect.TypeOf(v)
+	p := reflect.ValueOf(v)
+
+	if p.Kind() != reflect.Ptr {
+		panic("thrift.(*Decoder).Decode: expected pointer type but got " + t.String())
+	}
+
+	t = t.Elem()
+	p = p.Elem()
+
+	cache, _ := decoderCache.Load().(map[typeID]decodeFunc)
+	decode, _ := cache[makeTypeID(t)]
+
+	if decode == nil {
+		decode = decodeFuncOf(t, make(decodeFuncCache))
+
+		newCache := make(map[typeID]decodeFunc, len(cache)+1)
+		newCache[makeTypeID(t)] = decode
+		for k, v := range cache {
+			newCache[k] = v
+		}
+
+		decoderCache.Store(newCache)
+	}
+
+	return decode(d.r, p)
+}
+
+func (d *Decoder) Reset(r Reader) {
+	d.r = r
+}
+
+var decoderCache atomic.Value // map[typeID]decodeFunc
+
+type decodeFunc func(Reader, reflect.Value) error
+
+type decodeFuncCache map[reflect.Type]decodeFunc
+
+func decodeFuncOf(t reflect.Type, seen decodeFuncCache) decodeFunc {
+	f := seen[t]
+	if f != nil {
+		return f
+	}
+	switch t.Kind() {
+	case reflect.Bool:
+		f = decodeBool
+	case reflect.Int8:
+		f = decodeInt8
+	case reflect.Int16:
+		f = decodeInt16
+	case reflect.Int32:
+		f = decodeInt32
+	case reflect.Int64, reflect.Int:
+		f = decodeInt64
+	case reflect.Uint8:
+		f = decodeUint8
+	case reflect.Uint16:
+		f = decodeUint16
+	case reflect.Uint32:
+		f = decodeUint32
+	case reflect.Uint64, reflect.Uint, reflect.Uintptr:
+		f = decodeUint64
+	case reflect.Float32, reflect.Float64:
+		f = decodeFloat64
+	case reflect.String:
+		f = decodeString
+	case reflect.Slice:
+		if t.Elem().Kind() == reflect.Uint8 { // []byte
+			f = decodeBytes
+		} else {
+			f = decodeFuncSliceOf(t, seen)
+		}
+	case reflect.Map:
+		f = decodeFuncMapOf(t, seen)
+	case reflect.Struct:
+		f = decodeFuncStructOf(t, seen)
+	case reflect.Ptr:
+		f = decodeFuncPtrOf(t, seen)
+	default:
+		panic("type cannot be decoded in thrift: " + t.String())
+	}
+	seen[t] = f
+	return f
+}
+
+func decodeBool(r Reader, v reflect.Value) error {
+	b, err := r.ReadBool()
+	if err != nil {
+		return err
+	}
+	v.SetBool(b)
+	return nil
+}
+
+func decodeInt8(r Reader, v reflect.Value) error {
+	i, err := r.ReadInt8()
+	if err != nil {
+		return err
+	}
+	v.SetInt(int64(i))
+	return nil
+}
+
+func decodeInt16(r Reader, v reflect.Value) error {
+	i, err := r.ReadInt16()
+	if err != nil {
+		return err
+	}
+	v.SetInt(int64(i))
+	return nil
+}
+
+func decodeInt32(r Reader, v reflect.Value) error {
+	i, err := r.ReadInt32()
+	if err != nil {
+		return err
+	}
+	v.SetInt(int64(i))
+	return nil
+}
+
+func decodeInt64(r Reader, v reflect.Value) error {
+	i, err := r.ReadInt64()
+	if err != nil {
+		return err
+	}
+	v.SetInt(int64(i))
+	return nil
+}
+
+func decodeUint8(r Reader, v reflect.Value) error {
+	u, err := r.ReadInt8()
+	if err != nil {
+		return err
+	}
+	v.SetUint(uint64(u))
+	return nil
+}
+
+func decodeUint16(r Reader, v reflect.Value) error {
+	u, err := r.ReadInt16()
+	if err != nil {
+		return err
+	}
+	v.SetUint(uint64(u))
+	return nil
+}
+
+func decodeUint32(r Reader, v reflect.Value) error {
+	u, err := r.ReadInt32()
+	if err != nil {
+		return err
+	}
+	v.SetUint(uint64(u))
+	return nil
+}
+
+func decodeUint64(r Reader, v reflect.Value) error {
+	u, err := r.ReadInt64()
+	if err != nil {
+		return err
+	}
+	v.SetUint(uint64(u))
+	return nil
+}
+
+func decodeFloat64(r Reader, v reflect.Value) error {
+	f, err := r.ReadFloat64()
+	if err != nil {
+		return err
+	}
+	v.SetFloat(f)
+	return nil
+}
+
+func decodeString(r Reader, v reflect.Value) error {
+	s, err := r.ReadString()
+	if err != nil {
+		return err
+	}
+	v.SetString(s)
+	return nil
+}
+
+func decodeBytes(r Reader, v reflect.Value) error {
+	b, err := r.ReadBytes()
+	if err != nil {
+		return err
+	}
+	v.SetBytes(b)
+	return nil
+}
+
+func decodeFuncSliceOf(t reflect.Type, seen decodeFuncCache) decodeFunc {
+	elem := t.Elem()
+	typ := TypeOf(elem)
+	dec := decodeFuncOf(elem, seen)
+
+	return func(r Reader, v reflect.Value) error {
+		l, err := r.ReadList()
+		if err != nil {
+			return fmt.Errorf("decoding thrift list header: %w", err)
+		}
+
+		// TODO: implement type conversions?
+		if typ != l.Type {
+			return fmt.Errorf("element type mismatch in decoded thrift list of length %d: want %s but got %s", l.Size, typ, l.Type)
+		}
+
+		v.Set(reflect.MakeSlice(t, int(l.Size), int(l.Size)))
+
+		for i := 0; i < int(l.Size); i++ {
+			if err := dec(r, v.Index(i)); err != nil {
+				return fmt.Errorf("decoding thrift list element of type %s at index %d: %w", l.Type, i, err)
+			}
+		}
+
+		return nil
+	}
+}
+
+func decodeFuncMapOf(t reflect.Type, seen decodeFuncCache) decodeFunc {
+	key, elem := t.Key(), t.Elem()
+	if elem.Size() == 0 { // map[?]struct{}
+		return decodeFuncMapAsSetOf(t, seen)
+	}
+
+	mapType := reflect.MapOf(key, elem)
+	keyZero := reflect.Zero(key)
+	elemZero := reflect.Zero(elem)
+	keyType := TypeOf(key)
+	elemType := TypeOf(elem)
+	decodeKey := decodeFuncOf(key, seen)
+	decodeElem := decodeFuncOf(elem, seen)
+
+	return func(r Reader, v reflect.Value) error {
+		m, err := r.ReadMap()
+		if err != nil {
+			return fmt.Errorf("decoding thrift map header: %w", err)
+		}
+
+		v.Set(reflect.MakeMapWithSize(mapType, int(m.Size)))
+
+		if m.Size == 0 { // empty map
+			return nil
+		}
+
+		// TODO: implement type conversions?
+		if keyType != m.Key {
+			return fmt.Errorf("key type mismatch in decoded thrift map of length %d: want %s but got %s", m.Size, keyType, m.Key)
+		}
+		if elemType != m.Value {
+			return fmt.Errorf("value type mismatch in decoded thrift map of length %d: want %s but got %s", m.Size, elemType, m.Value)
+		}
+
+		tmpKey := reflect.New(key).Elem()
+		tmpElem := reflect.New(elem).Elem()
+
+		for i := 0; i < int(m.Size); i++ {
+			if err := decodeKey(r, tmpKey); err != nil {
+				return fmt.Errorf("decoding thrift map key of type %s at index %d: %w", m.Key, i, err)
+			}
+			if err := decodeElem(r, tmpElem); err != nil {
+				return fmt.Errorf("decoding thrift map value of type %s at index %d: %w", m.Value, i, err)
+			}
+			v.SetMapIndex(tmpKey, tmpElem)
+			tmpKey.Set(keyZero)
+			tmpElem.Set(elemZero)
+		}
+
+		return nil
+	}
+}
+
+func decodeFuncMapAsSetOf(t reflect.Type, seen decodeFuncCache) decodeFunc {
+	key, elem := t.Key(), t.Elem()
+	keyZero := reflect.Zero(key)
+	elemZero := reflect.Zero(elem)
+	typ := TypeOf(key)
+	dec := decodeFuncOf(key, seen)
+
+	return func(r Reader, v reflect.Value) error {
+		s, err := r.ReadSet()
+		if err != nil {
+			return fmt.Errorf("decoding thrift set header: %w", err)
+		}
+
+		v.Set(reflect.MakeMapWithSize(t, int(s.Size)))
+
+		if s.Size == 0 {
+			return nil
+		}
+
+		// TODO: implement type conversions?
+		if typ != s.Type {
+			return fmt.Errorf("element type mismatch in decoded thrift set of length %d: want %s but got %s", s.Size, typ, s.Type)
+		}
+
+		tmp := reflect.New(key).Elem()
+
+		for i := 0; i < int(s.Size); i++ {
+			if err := dec(r, tmp); err != nil {
+				return fmt.Errorf("decoding thrift set element of type %s at index %d: %w", s.Type, i, err)
+			}
+			v.SetMapIndex(tmp, elemZero)
+			tmp.Set(keyZero)
+		}
+
+		return nil
+	}
+}
+
+type structDecoder struct {
+	fields []structDecoderField
+	minID  int16
+	zero   reflect.Value
+}
+
+func (dec *structDecoder) decode(r Reader, v reflect.Value) error {
+	v.Set(dec.zero)
+	return readStruct(r, func(r Reader, f Field) error {
+		i := int(f.ID) - int(dec.minID)
+		if i < 0 || i >= len(dec.fields) || dec.fields[i].decode == nil {
+			return skipField(r, f)
+		}
+		field := &dec.fields[i]
+
+		// TODO: implement type conversions?
+		if f.Type != field.typ {
+			return fmt.Errorf("value type mismatch in decoded thrift struct field %d: want %s but got %s", f.ID, field.typ, f.Type)
+		}
+
+		x := v
+		for _, i := range field.index {
+			if x.Kind() == reflect.Ptr {
+				x = x.Elem()
+			}
+			if x = x.Field(i); x.Kind() == reflect.Ptr {
+				if x.IsNil() {
+					x.Set(reflect.New(x.Type().Elem()))
+				}
+			}
+		}
+
+		return field.decode(r, x)
+	})
+}
+
+type structDecoderField struct {
+	index  []int
+	id     int16
+	typ    Type
+	decode decodeFunc
+}
+
+func decodeFuncStructOf(t reflect.Type, seen decodeFuncCache) decodeFunc {
+	dec := &structDecoder{
+		zero: reflect.Zero(t),
+	}
+	decode := dec.decode
+	seen[t] = decode
+
+	fields := make([]structDecoderField, 0, t.NumField())
+	forEachStructField(t, nil, func(t reflect.Type, id int16, index []int) {
+		fields = append(fields, structDecoderField{
+			index:  index,
+			id:     id,
+			typ:    TypeOf(t),
+			decode: decodeFuncOf(t, seen),
+		})
+	})
+
+	minID := int16(0)
+	maxID := int16(0)
+
+	for _, f := range fields {
+		if f.id < minID || minID == 0 {
+			minID = f.id
+		}
+		if f.id > maxID {
+			maxID = f.id
+		}
+	}
+
+	dec.fields = make([]structDecoderField, (maxID-minID)+1)
+	dec.minID = minID
+
+	for _, f := range fields {
+		i := f.id - minID
+		if dec.fields[i].decode != nil {
+			panic(fmt.Errorf("thrift struct field id %d is present multiple times", f.id))
+		}
+		dec.fields[i] = f
+	}
+
+	return decode
+}
+
+func decodeFuncPtrOf(t reflect.Type, seen decodeFuncCache) decodeFunc {
+	elem := t.Elem()
+	decode := decodeFuncOf(t.Elem(), seen)
+	return func(r Reader, v reflect.Value) error {
+		if v.IsNil() {
+			v.Set(reflect.New(elem))
+		}
+		return decode(r, v.Elem())
+	}
+}
+
+func readBinary(r Reader, f func(io.Reader) error) error {
+	n, err := r.ReadLength()
+	if err != nil {
+		return fmt.Errorf("decoding thrift binary value length: %w", err)
+	}
+	if err := f(io.LimitReader(r.Reader(), int64(n))); err != nil {
+		return fmt.Errorf("decoding thrift binary value of length %d: %w", n, err)
+	}
+	return nil
+}
+
+func readList(r Reader, f func(Reader, Type) error) error {
+	l, err := r.ReadList()
+	if err != nil {
+		return fmt.Errorf("decoding thrift list header: %w", err)
+	}
+
+	for i := 0; i < int(l.Size); i++ {
+		if err := f(r, l.Type); err != nil {
+			return fmt.Errorf("decoding thrift list element of type %s at index %d: %w", l.Type, i, err)
+		}
+	}
+
+	return nil
+}
+
+func readSet(r Reader, f func(Reader, Type) error) error {
+	s, err := r.ReadSet()
+	if err != nil {
+		return fmt.Errorf("decoding thrift set header: %w", err)
+	}
+
+	for i := 0; i < int(s.Size); i++ {
+		if err := f(r, s.Type); err != nil {
+			return fmt.Errorf("decoding thrift set element of type %s at index %d: %w", s.Type, i, err)
+		}
+	}
+
+	return nil
+}
+
+func readMap(r Reader, f func(Reader, Type, Type) error) error {
+	m, err := r.ReadMap()
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < int(m.Size); i++ {
+		if err := f(r, m.Key, m.Value); err != nil {
+			return fmt.Errorf("decoding thrift map entry at index %d: %w", i, err)
+		}
+	}
+
+	return nil
+}
+
+func readStruct(r Reader, f func(Reader, Field) error) error {
+	for {
+		e, err := r.ReadField()
+		if err != nil {
+			return err
+		}
+
+		if e.ID == 0 && e.Type == 0 {
+			return nil
+		}
+
+		if err := f(r, e); err != nil {
+			return fmt.Errorf("decoding thrift struct field id %d of type %s: %w", e.ID, e.Type, err)
+		}
+	}
+}
+
+func skip(r Reader, t Type) error {
+	var err error
+	switch t {
+	case TRUE, FALSE:
+		_, err = r.ReadBool()
+	case I8:
+		_, err = r.ReadInt8()
+	case I16:
+		_, err = r.ReadInt16()
+	case I32:
+		_, err = r.ReadInt32()
+	case I64:
+		_, err = r.ReadInt64()
+	case DOUBLE:
+		_, err = r.ReadFloat64()
+	case BINARY:
+		err = skipBinary(r)
+	case LIST:
+		err = skipList(r)
+	case SET:
+		err = skipSet(r)
+	case MAP:
+		err = skipMap(r)
+	case STRUCT:
+		err = skipStruct(r)
+	default:
+		return fmt.Errorf("skipping unsupported thrift type %d", t)
+	}
+	return err
+}
+
+func skipField(r Reader, f Field) error {
+	if err := skip(r, f.Type); err != nil {
+		return fmt.Errorf("skipping thrift field id %d of type %s: %w", f.ID, f.Type, err)
+	}
+	return nil
+}
+
+func skipBinary(r Reader) error {
+	n, err := r.ReadLength()
+	if err != nil {
+		return err
+	}
+	switch x := r.Reader().(type) {
+	case *bufio.Reader:
+		_, err = x.Discard(int(n))
+	default:
+		_, err = io.CopyN(io.Discard, x, int64(n))
+	}
+	return err
+}
+
+func skipList(r Reader) error {
+	return readList(r, skip)
+}
+
+func skipSet(r Reader) error {
+	return readSet(r, skip)
+}
+
+func skipMap(r Reader) error {
+	return readMap(r, func(r Reader, k, v Type) error {
+		if err := skip(r, k); err != nil {
+			return fmt.Errorf("skipping thrift map key of type %s: %w", v, err)
+		}
+		if err := skip(r, v); err != nil {
+			return fmt.Errorf("skipping thrift map value of type %s: %w", v, err)
+		}
+		return nil
+	})
+}
+
+func skipStruct(r Reader) error {
+	return readStruct(r, skipField)
+}

--- a/thrift/decode.go
+++ b/thrift/decode.go
@@ -450,7 +450,7 @@ func (dec *structDecoder) decode(r Reader, v reflect.Value, flags flags) error {
 	for i, required := range dec.required {
 		if mask := required & seen[i]; mask != required {
 			index := bits.TrailingZeros64(mask)
-			field := &dec.fields[i/64+index]
+			field := &dec.fields[i+index]
 			return &MissingField{Field: Field{ID: field.id, Type: field.typ}}
 		}
 	}

--- a/thrift/decode.go
+++ b/thrift/decode.go
@@ -108,14 +108,6 @@ func decodeFuncOf(t reflect.Type, seen decodeFuncCache) decodeFunc {
 		f = decodeInt32
 	case reflect.Int64, reflect.Int:
 		f = decodeInt64
-	case reflect.Uint8:
-		f = decodeUint8
-	case reflect.Uint16:
-		f = decodeUint16
-	case reflect.Uint32:
-		f = decodeUint32
-	case reflect.Uint64, reflect.Uint, reflect.Uintptr:
-		f = decodeUint64
 	case reflect.Float32, reflect.Float64:
 		f = decodeFloat64
 	case reflect.String:
@@ -181,42 +173,6 @@ func decodeInt64(r Reader, v reflect.Value, _ flags) error {
 		return err
 	}
 	v.SetInt(int64(i))
-	return nil
-}
-
-func decodeUint8(r Reader, v reflect.Value, _ flags) error {
-	u, err := r.ReadInt8()
-	if err != nil {
-		return err
-	}
-	v.SetUint(uint64(u))
-	return nil
-}
-
-func decodeUint16(r Reader, v reflect.Value, _ flags) error {
-	u, err := r.ReadInt16()
-	if err != nil {
-		return err
-	}
-	v.SetUint(uint64(u))
-	return nil
-}
-
-func decodeUint32(r Reader, v reflect.Value, _ flags) error {
-	u, err := r.ReadInt32()
-	if err != nil {
-		return err
-	}
-	v.SetUint(uint64(u))
-	return nil
-}
-
-func decodeUint64(r Reader, v reflect.Value, _ flags) error {
-	u, err := r.ReadInt64()
-	if err != nil {
-		return err
-	}
-	v.SetUint(uint64(u))
 	return nil
 }
 
@@ -528,8 +484,6 @@ func decodeFuncStructFieldOf(f structField, seen decodeFuncCache) decodeFunc {
 		switch f.typ.Kind() {
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 			return decodeInt32
-		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-			return decodeUint32
 		}
 	}
 	return decodeFuncOf(f.typ, seen)

--- a/thrift/decode_test.go
+++ b/thrift/decode_test.go
@@ -1,0 +1,19 @@
+package thrift_test
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/segmentio/encoding/thrift"
+)
+
+func TestDecodeEOF(t *testing.T) {
+	p := thrift.CompactProtocol{}
+	d := thrift.NewDecoder(p.NewReader(bytes.NewReader(nil)))
+	v := struct{ Name string }{}
+
+	if err := d.Decode(&v); err != io.EOF {
+		t.Errorf("unexpected error returned: %v", err)
+	}
+}

--- a/thrift/encode.go
+++ b/thrift/encode.go
@@ -307,12 +307,12 @@ func encodeFuncStructOf(t reflect.Type, seen encodeFuncCache) encodeFunc {
 	encode := enc.encode
 	seen[t] = encode
 
-	forEachStructField(t, nil, func(t reflect.Type, id int16, index []int) {
+	forEachStructField(t, nil, func(f structField) {
 		enc.fields = append(enc.fields, structEncoderField{
-			index:  index,
-			id:     id,
-			typ:    TypeOf(t),
-			encode: encodeFuncOf(t, seen),
+			index:  f.index,
+			id:     f.id,
+			typ:    TypeOf(f.typ),
+			encode: encodeFuncStructFieldOf(f, seen),
 		})
 	})
 
@@ -327,6 +327,18 @@ func encodeFuncStructOf(t reflect.Type, seen encodeFuncCache) encodeFunc {
 	}
 
 	return encode
+}
+
+func encodeFuncStructFieldOf(f structField, seen encodeFuncCache) encodeFunc {
+	if f.enum {
+		switch f.typ.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			return encodeInt32
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+			return encodeUint32
+		}
+	}
+	return encodeFuncOf(f.typ, seen)
 }
 
 func encodeFuncPtrOf(t reflect.Type, seen encodeFuncCache) encodeFunc {

--- a/thrift/encode.go
+++ b/thrift/encode.go
@@ -1,0 +1,353 @@
+package thrift
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"reflect"
+	"sort"
+	"sync/atomic"
+)
+
+func Marshal(p Protocol, v interface{}) ([]byte, error) {
+	buf := new(bytes.Buffer)
+	enc := NewEncoder(p.NewWriter(buf))
+	err := enc.Encode(v)
+	return buf.Bytes(), err
+}
+
+type Encoder struct {
+	w Writer
+}
+
+func NewEncoder(w Writer) *Encoder {
+	return &Encoder{w: w}
+}
+
+func (e *Encoder) Encode(v interface{}) error {
+	t := reflect.TypeOf(v)
+	cache, _ := encoderCache.Load().(map[typeID]encodeFunc)
+	encode, _ := cache[makeTypeID(t)]
+
+	if encode == nil {
+		encode = encodeFuncOf(t, make(encodeFuncCache))
+
+		newCache := make(map[typeID]encodeFunc, len(cache)+1)
+		newCache[makeTypeID(t)] = encode
+		for k, v := range cache {
+			newCache[k] = v
+		}
+
+		encoderCache.Store(newCache)
+	}
+
+	return encode(e.w, reflect.ValueOf(v))
+}
+
+func (e *Encoder) Reset(w Writer) {
+	e.w = w
+}
+
+var encoderCache atomic.Value // map[typeID]encodeFunc
+
+type encodeFunc func(Writer, reflect.Value) error
+
+type encodeFuncCache map[reflect.Type]encodeFunc
+
+func encodeFuncOf(t reflect.Type, seen encodeFuncCache) encodeFunc {
+	f := seen[t]
+	if f != nil {
+		return f
+	}
+	switch t.Kind() {
+	case reflect.Bool:
+		f = encodeBool
+	case reflect.Int8:
+		f = encodeInt8
+	case reflect.Int16:
+		f = encodeInt16
+	case reflect.Int32:
+		f = encodeInt32
+	case reflect.Int64, reflect.Int:
+		f = encodeInt64
+	case reflect.Uint8:
+		f = encodeUint8
+	case reflect.Uint16:
+		f = encodeUint16
+	case reflect.Uint32:
+		f = encodeUint32
+	case reflect.Uint64, reflect.Uint, reflect.Uintptr:
+		f = encodeUint64
+	case reflect.Float32, reflect.Float64:
+		f = encodeFloat64
+	case reflect.String:
+		f = encodeString
+	case reflect.Slice:
+		if t.Elem().Kind() == reflect.Uint8 {
+			f = encodeBytes
+		} else {
+			f = encodeFuncSliceOf(t, seen)
+		}
+	case reflect.Map:
+		f = encodeFuncMapOf(t, seen)
+	case reflect.Struct:
+		f = encodeFuncStructOf(t, seen)
+	case reflect.Ptr:
+		f = encodeFuncPtrOf(t, seen)
+	default:
+		panic("type cannot be encoded in thrift: " + t.String())
+	}
+	seen[t] = f
+	return f
+}
+
+func encodeBool(w Writer, v reflect.Value) error {
+	return w.WriteBool(v.Bool())
+}
+
+func encodeInt8(w Writer, v reflect.Value) error {
+	return w.WriteInt8(int8(v.Int()))
+}
+
+func encodeInt16(w Writer, v reflect.Value) error {
+	return w.WriteInt16(int16(v.Int()))
+}
+
+func encodeInt32(w Writer, v reflect.Value) error {
+	return w.WriteInt32(int32(v.Int()))
+}
+
+func encodeInt64(w Writer, v reflect.Value) error {
+	return w.WriteInt64(v.Int())
+}
+
+func encodeUint8(w Writer, v reflect.Value) error {
+	return w.WriteInt8(int8(v.Uint()))
+}
+
+func encodeUint16(w Writer, v reflect.Value) error {
+	return w.WriteInt16(int16(v.Uint()))
+}
+
+func encodeUint32(w Writer, v reflect.Value) error {
+	return w.WriteInt32(int32(v.Uint()))
+}
+
+func encodeUint64(w Writer, v reflect.Value) error {
+	return w.WriteInt64(int64(v.Uint()))
+}
+
+func encodeFloat64(w Writer, v reflect.Value) error {
+	return w.WriteFloat64(v.Float())
+}
+
+func encodeString(w Writer, v reflect.Value) error {
+	return w.WriteString(v.String())
+}
+
+func encodeBytes(w Writer, v reflect.Value) error {
+	return w.WriteBytes(v.Bytes())
+}
+
+func encodeFuncSliceOf(t reflect.Type, seen encodeFuncCache) encodeFunc {
+	elem := t.Elem()
+	typ := TypeOf(elem)
+	enc := encodeFuncOf(elem, seen)
+
+	return func(w Writer, v reflect.Value) error {
+		n := v.Len()
+		if n > math.MaxInt32 {
+			return fmt.Errorf("slice length is too large to be represented in thrift: %d > max(int32)", n)
+		}
+
+		err := w.WriteList(List{
+			Size: int32(n),
+			Type: typ,
+		})
+		if err != nil {
+			return fmt.Errorf("encoding thrift list header: %w", err)
+		}
+
+		for i := 0; i < n; i++ {
+			if err := enc(w, v.Index(i)); err != nil {
+				return fmt.Errorf("encoding thrift list element of type %s at index %d: %w", typ, i, err)
+			}
+		}
+
+		return nil
+	}
+}
+
+func encodeFuncMapOf(t reflect.Type, seen encodeFuncCache) encodeFunc {
+	key, elem := t.Key(), t.Elem()
+	if elem.Size() == 0 { // map[?]struct{}
+		return encodeFuncMapAsSetOf(t, seen)
+	}
+
+	keyType := TypeOf(key)
+	elemType := TypeOf(elem)
+	encodeKey := encodeFuncOf(key, seen)
+	encodeElem := encodeFuncOf(elem, seen)
+
+	return func(w Writer, v reflect.Value) error {
+		n := v.Len()
+		if n > math.MaxInt32 {
+			return fmt.Errorf("map length is too large to be represented in thrift: %d > max(int32)", n)
+		}
+
+		err := w.WriteMap(Map{
+			Size:  int32(n),
+			Key:   keyType,
+			Value: elemType,
+		})
+		if err != nil {
+			return fmt.Errorf("encoding thrift map header: %w", err)
+		}
+		if n == 0 { // empty map
+			return nil
+		}
+
+		for i, iter := 0, v.MapRange(); iter.Next(); i++ {
+			if err := encodeKey(w, iter.Key()); err != nil {
+				return fmt.Errorf("encoding thrift map key of type %s at index %d: %w", keyType, i, err)
+			}
+			if err := encodeElem(w, iter.Value()); err != nil {
+				return fmt.Errorf("encoding thrift map value of type %s at index %d: %w", elemType, i, err)
+			}
+		}
+
+		return nil
+	}
+}
+
+func encodeFuncMapAsSetOf(t reflect.Type, seen encodeFuncCache) encodeFunc {
+	key := t.Key()
+	typ := TypeOf(key)
+	enc := encodeFuncOf(key, seen)
+
+	return func(w Writer, v reflect.Value) error {
+		n := v.Len()
+		if n > math.MaxInt32 {
+			return fmt.Errorf("map length is too large to be represented in thrift: %d > max(int32)", n)
+		}
+
+		err := w.WriteSet(Set{
+			Size: int32(n),
+			Type: typ,
+		})
+		if err != nil {
+			return fmt.Errorf("encoding thrift set header: %w", err)
+		}
+		if n == 0 { // empty map
+			return nil
+		}
+
+		for i, iter := 0, v.MapRange(); iter.Next(); i++ {
+			if err := enc(w, iter.Key()); err != nil {
+				return fmt.Errorf("encoding thrift set element of type %s at index %d: %w", typ, i, err)
+			}
+		}
+
+		return nil
+	}
+}
+
+type structEncoder struct {
+	fields []structEncoderField
+}
+
+func (enc *structEncoder) encode(w Writer, v reflect.Value) error {
+encodeFields:
+	for _, f := range enc.fields {
+		x := v
+		for _, i := range f.index {
+			if x.Kind() == reflect.Ptr {
+				x = x.Elem()
+			}
+			if x = x.Field(i); x.Kind() == reflect.Ptr {
+				if x.IsNil() {
+					continue encodeFields
+				}
+			}
+		}
+
+		if isZero(x) {
+			continue encodeFields
+		}
+		if err := w.WriteField(Field{ID: f.id, Type: f.typ}); err != nil {
+			return fmt.Errorf("encoding thrift struct field id %d of type %s: %w", f.id, f.typ, err)
+		}
+		if err := f.encode(w, x); err != nil {
+			return fmt.Errorf("encoding thrift struct field value: %w", err)
+		}
+	}
+
+	if err := w.WriteField(Field{}); err != nil {
+		return fmt.Errorf("encoding thrift struct stop field: %w", err)
+	}
+
+	return nil
+}
+
+type structEncoderField struct {
+	index  []int
+	id     int16
+	typ    Type
+	encode encodeFunc
+}
+
+func encodeFuncStructOf(t reflect.Type, seen encodeFuncCache) encodeFunc {
+	enc := &structEncoder{
+		fields: make([]structEncoderField, 0, t.NumField()),
+	}
+	encode := enc.encode
+	seen[t] = encode
+
+	forEachStructField(t, nil, func(t reflect.Type, id int16, index []int) {
+		enc.fields = append(enc.fields, structEncoderField{
+			index:  index,
+			id:     id,
+			typ:    TypeOf(t),
+			encode: encodeFuncOf(t, seen),
+		})
+	})
+
+	sort.SliceStable(enc.fields, func(i, j int) bool {
+		return enc.fields[i].id < enc.fields[j].id
+	})
+
+	for i := len(enc.fields) - 1; i > 0; i-- {
+		if enc.fields[i-1].id == enc.fields[i].id {
+			panic(fmt.Errorf("thrift struct field id %d is present multiple times", enc.fields[i].id))
+		}
+	}
+
+	return encode
+}
+
+func encodeFuncPtrOf(t reflect.Type, seen encodeFuncCache) encodeFunc {
+	typ := t.Elem()
+	enc := encodeFuncOf(typ, seen)
+	zero := reflect.Zero(typ)
+
+	return func(w Writer, v reflect.Value) error {
+		if v.IsNil() {
+			v = zero
+		}
+		return enc(w, v)
+	}
+}
+
+func isZero(v reflect.Value) bool {
+	if !v.IsValid() {
+		return true
+	}
+	switch v.Kind() {
+	case reflect.Ptr:
+		return v.IsNil()
+	case reflect.Slice, reflect.Map:
+		return v.Len() == 0
+	default:
+		return v.IsZero()
+	}
+}

--- a/thrift/encode.go
+++ b/thrift/encode.go
@@ -80,14 +80,6 @@ func encodeFuncOf(t reflect.Type, seen encodeFuncCache) encodeFunc {
 		f = encodeInt32
 	case reflect.Int64, reflect.Int:
 		f = encodeInt64
-	case reflect.Uint8:
-		f = encodeUint8
-	case reflect.Uint16:
-		f = encodeUint16
-	case reflect.Uint32:
-		f = encodeUint32
-	case reflect.Uint64, reflect.Uint, reflect.Uintptr:
-		f = encodeUint64
 	case reflect.Float32, reflect.Float64:
 		f = encodeFloat64
 	case reflect.String:
@@ -129,22 +121,6 @@ func encodeInt32(w Writer, v reflect.Value, _ flags) error {
 
 func encodeInt64(w Writer, v reflect.Value, _ flags) error {
 	return w.WriteInt64(v.Int())
-}
-
-func encodeUint8(w Writer, v reflect.Value, _ flags) error {
-	return w.WriteInt8(int8(v.Uint()))
-}
-
-func encodeUint16(w Writer, v reflect.Value, _ flags) error {
-	return w.WriteInt16(int16(v.Uint()))
-}
-
-func encodeUint32(w Writer, v reflect.Value, _ flags) error {
-	return w.WriteInt32(int32(v.Uint()))
-}
-
-func encodeUint64(w Writer, v reflect.Value, _ flags) error {
-	return w.WriteInt64(int64(v.Uint()))
 }
 
 func encodeFloat64(w Writer, v reflect.Value, _ flags) error {
@@ -387,8 +363,6 @@ func encodeFuncStructFieldOf(f structField, seen encodeFuncCache) encodeFunc {
 		switch f.typ.Kind() {
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 			return encodeInt32
-		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-			return encodeUint32
 		}
 	}
 	return encodeFuncOf(f.typ, seen)

--- a/thrift/encode.go
+++ b/thrift/encode.go
@@ -9,6 +9,10 @@ import (
 	"sync/atomic"
 )
 
+// Marshal serializes v into a thrift representation according to the the
+// protocol p.
+//
+// The function panics if v cannot be converted to a thrift representation.
 func Marshal(p Protocol, v interface{}) ([]byte, error) {
 	buf := new(bytes.Buffer)
 	enc := NewEncoder(p.NewWriter(buf))

--- a/thrift/encode.go
+++ b/thrift/encode.go
@@ -169,12 +169,12 @@ func encodeFuncSliceOf(t reflect.Type, seen encodeFuncCache) encodeFunc {
 			Type: typ,
 		})
 		if err != nil {
-			return fmt.Errorf("encoding thrift list header: %w", err)
+			return err
 		}
 
 		for i := 0; i < n; i++ {
 			if err := enc(w, v.Index(i), noflags); err != nil {
-				return fmt.Errorf("encoding thrift list element of type %s at index %d: %w", typ, i, err)
+				return err
 			}
 		}
 
@@ -205,7 +205,7 @@ func encodeFuncMapOf(t reflect.Type, seen encodeFuncCache) encodeFunc {
 			Value: elemType,
 		})
 		if err != nil {
-			return fmt.Errorf("encoding thrift map header: %w", err)
+			return err
 		}
 		if n == 0 { // empty map
 			return nil
@@ -213,10 +213,10 @@ func encodeFuncMapOf(t reflect.Type, seen encodeFuncCache) encodeFunc {
 
 		for i, iter := 0, v.MapRange(); iter.Next(); i++ {
 			if err := encodeKey(w, iter.Key(), noflags); err != nil {
-				return fmt.Errorf("encoding thrift map key of type %s at index %d: %w", keyType, i, err)
+				return err
 			}
 			if err := encodeElem(w, iter.Value(), noflags); err != nil {
-				return fmt.Errorf("encoding thrift map value of type %s at index %d: %w", elemType, i, err)
+				return err
 			}
 		}
 
@@ -240,7 +240,7 @@ func encodeFuncMapAsSetOf(t reflect.Type, seen encodeFuncCache) encodeFunc {
 			Type: typ,
 		})
 		if err != nil {
-			return fmt.Errorf("encoding thrift set header: %w", err)
+			return err
 		}
 		if n == 0 { // empty map
 			return nil
@@ -248,7 +248,7 @@ func encodeFuncMapAsSetOf(t reflect.Type, seen encodeFuncCache) encodeFunc {
 
 		for i, iter := 0, v.MapRange(); iter.Next(); i++ {
 			if err := enc(w, iter.Key(), noflags); err != nil {
-				return fmt.Errorf("encoding thrift set element of type %s at index %d: %w", typ, i, err)
+				return err
 			}
 		}
 
@@ -291,18 +291,18 @@ encodeFields:
 		}
 
 		if err := w.WriteField(field); err != nil {
-			return fmt.Errorf("encoding thrift %s field id %d of type %s: %w", enc, f.id, f.typ, err)
+			return err
 		}
 
 		if err := f.encode(w, x, f.flags); err != nil {
-			return fmt.Errorf("encoding thrift %s field value: %w", enc, err)
+			return err
 		}
 
 		numFields++
 	}
 
 	if err := w.WriteField(Field{}); err != nil {
-		return fmt.Errorf("encoding thrift %s stop field: %w", enc, err)
+		return err
 	}
 
 	if numFields > 1 && enc.union {

--- a/thrift/encode.go
+++ b/thrift/encode.go
@@ -278,7 +278,7 @@ encodeFields:
 			}
 		}
 
-		if !f.flags.have(required) && isZero(x) {
+		if !f.flags.have(required) && x.IsZero() {
 			continue encodeFields
 		}
 
@@ -383,19 +383,5 @@ func encodeFuncPtrOf(t reflect.Type, seen encodeFuncCache) encodeFunc {
 			v = zero
 		}
 		return enc(w, v, f)
-	}
-}
-
-func isZero(v reflect.Value) bool {
-	if !v.IsValid() {
-		return true
-	}
-	switch v.Kind() {
-	case reflect.Ptr:
-		return v.IsNil()
-	case reflect.Slice, reflect.Map:
-		return v.Len() == 0
-	default:
-		return v.IsZero()
 	}
 }

--- a/thrift/encode.go
+++ b/thrift/encode.go
@@ -277,7 +277,7 @@ encodeFields:
 			}
 		}
 
-		if isZero(x) {
+		if !f.flags.have(required) && isZero(x) {
 			continue encodeFields
 		}
 

--- a/thrift/error.go
+++ b/thrift/error.go
@@ -73,7 +73,7 @@ type decodeErrorList struct {
 }
 
 func (d *decodeErrorList) Error() string {
-	return fmt.Sprintf("%s[index=%d]", d.list, d.index)
+	return fmt.Sprintf("%d/%d:%s", d.index, d.list.Size, d.list)
 }
 
 type decodeErrorSet struct {
@@ -82,7 +82,7 @@ type decodeErrorSet struct {
 }
 
 func (d *decodeErrorSet) Error() string {
-	return fmt.Sprintf("%s[index=%d]", d.set, d.index)
+	return fmt.Sprintf("%d/%d:%s", d.index, d.set.Size, d.set)
 }
 
 type decodeErrorMap struct {
@@ -91,5 +91,5 @@ type decodeErrorMap struct {
 }
 
 func (d *decodeErrorMap) Error() string {
-	return fmt.Sprintf("%s[index=%d]", d._map, d.index)
+	return fmt.Sprintf("%d/%d:%s", d.index, d._map.Size, d._map)
 }

--- a/thrift/error.go
+++ b/thrift/error.go
@@ -1,0 +1,95 @@
+package thrift
+
+import (
+	"fmt"
+	"strings"
+)
+
+type MissingField struct {
+	Field Field
+}
+
+func (e *MissingField) Error() string {
+	return fmt.Sprintf("missing required field: %s", e.Field)
+}
+
+type TypeMismatch struct {
+	Expect Type
+	Found  Type
+	item   string
+}
+
+func (e *TypeMismatch) Error() string {
+	return fmt.Sprintf("%s type mismatch: expected %s but found %s", e.item, e.Expect, e.Found)
+}
+
+type decodeError struct {
+	base error
+	path []error
+}
+
+func (e *decodeError) Error() string {
+	s := strings.Builder{}
+	s.Grow(256)
+	s.WriteString("decoding thrift payload: ")
+
+	if len(e.path) != 0 {
+		n := len(e.path) - 1
+		for i := n; i >= 0; i-- {
+			if i < n {
+				s.WriteString(" → ")
+			}
+			s.WriteString(e.path[i].Error())
+		}
+		s.WriteString(": ")
+	}
+
+	s.WriteString(e.base.Error())
+	return s.String()
+}
+
+func (e *decodeError) Unwrap() error { return e.base }
+
+func with(base, elem error) error {
+	e, _ := base.(*decodeError)
+	if e == nil {
+		e = &decodeError{base: base}
+	}
+	e.path = append(e.path, elem)
+	return e
+}
+
+type decodeErrorField struct {
+	field Field
+}
+
+func (d *decodeErrorField) Error() string {
+	return d.field.String()
+}
+
+type decodeErrorList struct {
+	list  List
+	index int
+}
+
+func (d *decodeErrorList) Error() string {
+	return fmt.Sprintf("%s[index=%d]", d.list, d.index)
+}
+
+type decodeErrorSet struct {
+	set   Set
+	index int
+}
+
+func (d *decodeErrorSet) Error() string {
+	return fmt.Sprintf("%s[index=%d]", d.set, d.index)
+}
+
+type decodeErrorMap struct {
+	_map  Map
+	index int
+}
+
+func (d *decodeErrorMap) Error() string {
+	return fmt.Sprintf("%s[index=%d]", d._map, d.index)
+}

--- a/thrift/error.go
+++ b/thrift/error.go
@@ -65,38 +65,38 @@ func with(base, elem error) error {
 }
 
 type decodeErrorField struct {
-	field Field
+	cause Field
 }
 
 func (d *decodeErrorField) Error() string {
-	return d.field.String()
+	return d.cause.String()
 }
 
 type decodeErrorList struct {
-	list  List
+	cause List
 	index int
 }
 
 func (d *decodeErrorList) Error() string {
-	return fmt.Sprintf("%d/%d:%s", d.index, d.list.Size, d.list)
+	return fmt.Sprintf("%d/%d:%s", d.index, d.cause.Size, d.cause)
 }
 
 type decodeErrorSet struct {
-	set   Set
+	cause Set
 	index int
 }
 
 func (d *decodeErrorSet) Error() string {
-	return fmt.Sprintf("%d/%d:%s", d.index, d.set.Size, d.set)
+	return fmt.Sprintf("%d/%d:%s", d.index, d.cause.Size, d.cause)
 }
 
 type decodeErrorMap struct {
-	_map  Map
+	cause Map
 	index int
 }
 
 func (d *decodeErrorMap) Error() string {
-	return fmt.Sprintf("%d/%d:%s", d.index, d._map.Size, d._map)
+	return fmt.Sprintf("%d/%d:%s", d.index, d.cause.Size, d.cause)
 }
 
 func dontExpectEOF(err error) error {

--- a/thrift/protocol.go
+++ b/thrift/protocol.go
@@ -1,17 +1,16 @@
 package thrift
 
 import (
-	"bufio"
 	"io"
 )
 
 type Protocol interface {
-	NewReader(r *bufio.Reader) Reader
-	NewWriter(w *bufio.Writer) Writer
+	NewReader(r io.Reader) Reader
+	NewWriter(w io.Writer) Writer
 }
 
 type Reader interface {
-	io.Reader
+	Reader() io.Reader
 	ReadBool() (bool, error)
 	ReadInt8() (int8, error)
 	ReadInt16() (int16, error)
@@ -24,11 +23,12 @@ type Reader interface {
 	ReadMessage() (Message, error)
 	ReadField() (Field, error)
 	ReadList() (List, error)
+	ReadSet() (Set, error)
 	ReadMap() (Map, error)
 }
 
 type Writer interface {
-	io.Writer
+	Writer() io.Writer
 	WriteBool(bool) error
 	WriteInt8(int8) error
 	WriteInt16(int16) error
@@ -41,5 +41,6 @@ type Writer interface {
 	WriteMessage(Message) error
 	WriteField(Field) error
 	WriteList(List) error
+	WriteSet(Set) error
 	WriteMap(Map) error
 }

--- a/thrift/protocol.go
+++ b/thrift/protocol.go
@@ -4,11 +4,19 @@ import (
 	"io"
 )
 
+// The Protocol interface abstracts the creation of low-level thrift readers and
+// writers implementing the various protocols that the encoding supports.
+//
+// Protocol instances must be safe to use concurrently from multiple gourintes.
+// However, the readers and writer that they instantiates are intended to be
+// used by a single goroutine.
 type Protocol interface {
 	NewReader(r io.Reader) Reader
 	NewWriter(w io.Writer) Writer
 }
 
+// Reader represents a low-level reader of values encoded according to one of
+// the thrift protocols.
 type Reader interface {
 	Reader() io.Reader
 	ReadBool() (bool, error)
@@ -27,6 +35,8 @@ type Reader interface {
 	ReadMap() (Map, error)
 }
 
+// Writer represents a low-level writer of values encoded according to one of
+// the thrift protocols.
 type Writer interface {
 	Writer() io.Writer
 	WriteBool(bool) error

--- a/thrift/protocol.go
+++ b/thrift/protocol.go
@@ -1,0 +1,45 @@
+package thrift
+
+import (
+	"bufio"
+	"io"
+)
+
+type Protocol interface {
+	NewReader(r *bufio.Reader) Reader
+	NewWriter(w *bufio.Writer) Writer
+}
+
+type Reader interface {
+	io.Reader
+	ReadBool() (bool, error)
+	ReadInt8() (int8, error)
+	ReadInt16() (int16, error)
+	ReadInt32() (int32, error)
+	ReadInt64() (int64, error)
+	ReadFloat64() (float64, error)
+	ReadBytes() ([]byte, error)
+	ReadString() (string, error)
+	ReadLength() (int, error)
+	ReadMessage() (Message, error)
+	ReadField() (Field, error)
+	ReadList() (List, error)
+	ReadMap() (Map, error)
+}
+
+type Writer interface {
+	io.Writer
+	WriteBool(bool) error
+	WriteInt8(int8) error
+	WriteInt16(int16) error
+	WriteInt32(int32) error
+	WriteInt64(int64) error
+	WriteFloat64(float64) error
+	WriteBytes([]byte) error
+	WriteString(string) error
+	WriteLength(int) error
+	WriteMessage(Message) error
+	WriteField(Field) error
+	WriteList(List) error
+	WriteMap(Map) error
+}

--- a/thrift/protocol.go
+++ b/thrift/protocol.go
@@ -4,6 +4,20 @@ import (
 	"io"
 )
 
+// Features is a bitset describing the thrift encoding features supported by
+// protocol implementations.
+type Features uint
+
+const (
+	// DeltaEncoding is advertised by protocols that allow encoders to apply
+	// delta encoding on struct fields.
+	UseDeltaEncoding Features = 1 << iota
+
+	// CoalesceBoolFields is advertised by protocols that allow encoders to
+	// coalesce boolean values into field types.
+	CoalesceBoolFields
+)
+
 // The Protocol interface abstracts the creation of low-level thrift readers and
 // writers implementing the various protocols that the encoding supports.
 //
@@ -13,11 +27,13 @@ import (
 type Protocol interface {
 	NewReader(r io.Reader) Reader
 	NewWriter(w io.Writer) Writer
+	Features() Features
 }
 
 // Reader represents a low-level reader of values encoded according to one of
 // the thrift protocols.
 type Reader interface {
+	Protocol() Protocol
 	Reader() io.Reader
 	ReadBool() (bool, error)
 	ReadInt8() (int8, error)
@@ -38,6 +54,7 @@ type Reader interface {
 // Writer represents a low-level writer of values encoded according to one of
 // the thrift protocols.
 type Writer interface {
+	Protocol() Protocol
 	Writer() io.Writer
 	WriteBool(bool) error
 	WriteInt8(int8) error

--- a/thrift/protocol_test.go
+++ b/thrift/protocol_test.go
@@ -1,0 +1,190 @@
+package thrift_test
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/segmentio/encoding/thrift"
+)
+
+var protocolReadWriteTests = [...]struct {
+	scenario string
+	read     interface{}
+	write    interface{}
+	values   []interface{}
+}{
+	{
+		scenario: "bool",
+		read:     thrift.Reader.ReadBool,
+		write:    thrift.Writer.WriteBool,
+		values:   []interface{}{false, true},
+	},
+
+	{
+		scenario: "int8",
+		read:     thrift.Reader.ReadInt8,
+		write:    thrift.Writer.WriteInt8,
+		values:   []interface{}{int8(0), int8(1), int8(-1)},
+	},
+
+	{
+		scenario: "int16",
+		read:     thrift.Reader.ReadInt16,
+		write:    thrift.Writer.WriteInt16,
+		values:   []interface{}{int16(0), int16(1), int16(-1)},
+	},
+
+	{
+		scenario: "int32",
+		read:     thrift.Reader.ReadInt32,
+		write:    thrift.Writer.WriteInt32,
+		values:   []interface{}{int32(0), int32(1), int32(-1)},
+	},
+
+	{
+		scenario: "int64",
+		read:     thrift.Reader.ReadInt64,
+		write:    thrift.Writer.WriteInt64,
+		values:   []interface{}{int64(0), int64(1), int64(-1)},
+	},
+
+	{
+		scenario: "float64",
+		read:     thrift.Reader.ReadFloat64,
+		write:    thrift.Writer.WriteFloat64,
+		values:   []interface{}{float64(0), float64(1), float64(-1)},
+	},
+
+	{
+		scenario: "bytes",
+		read:     thrift.Reader.ReadBytes,
+		write:    thrift.Writer.WriteBytes,
+		values: []interface{}{
+			[]byte(""),
+			[]byte("A"),
+			[]byte("1234567890"),
+			bytes.Repeat([]byte("qwertyuiop"), 100),
+		},
+	},
+
+	{
+		scenario: "string",
+		read:     thrift.Reader.ReadString,
+		write:    thrift.Writer.WriteString,
+		values: []interface{}{
+			"",
+			"A",
+			"1234567890",
+			strings.Repeat("qwertyuiop", 100),
+		},
+	},
+
+	{
+		scenario: "message",
+		read:     thrift.Reader.ReadMessage,
+		write:    thrift.Writer.WriteMessage,
+		values: []interface{}{
+			thrift.Message{},
+			thrift.Message{Type: thrift.Call, Name: "Hello", SeqID: 10},
+			thrift.Message{Type: thrift.Reply, Name: "World", SeqID: 11},
+			thrift.Message{Type: thrift.Exception, Name: "Foo", SeqID: 40},
+			thrift.Message{Type: thrift.Oneway, Name: "Bar", SeqID: 42},
+		},
+	},
+
+	{
+		scenario: "field",
+		read:     thrift.Reader.ReadField,
+		write:    thrift.Writer.WriteField,
+		values: []interface{}{
+			thrift.Field{ID: 101, Type: thrift.TRUE},
+			thrift.Field{ID: 102, Type: thrift.FALSE},
+			thrift.Field{ID: 103, Type: thrift.I8},
+			thrift.Field{ID: 104, Type: thrift.I16},
+			thrift.Field{ID: 105, Type: thrift.I32},
+			thrift.Field{ID: 106, Type: thrift.I64},
+			thrift.Field{ID: 107, Type: thrift.DOUBLE},
+			thrift.Field{ID: 108, Type: thrift.BINARY},
+			thrift.Field{ID: 109, Type: thrift.LIST},
+			thrift.Field{ID: 110, Type: thrift.SET},
+			thrift.Field{ID: 111, Type: thrift.MAP},
+			thrift.Field{ID: 112, Type: thrift.STRUCT},
+			thrift.Field{},
+		},
+	},
+
+	{
+		scenario: "list",
+		read:     thrift.Reader.ReadList,
+		write:    thrift.Writer.WriteList,
+		values: []interface{}{
+			thrift.List{},
+			thrift.List{Size: 0, Type: thrift.BOOL},
+			thrift.List{Size: 1, Type: thrift.I8},
+			thrift.List{Size: 1000, Type: thrift.BINARY},
+		},
+	},
+
+	{
+		scenario: "map",
+		read:     thrift.Reader.ReadMap,
+		write:    thrift.Writer.WriteMap,
+		values: []interface{}{
+			thrift.Map{},
+			thrift.Map{Size: 1, Key: thrift.BINARY, Value: thrift.MAP},
+			thrift.Map{Size: 1000, Key: thrift.BINARY, Value: thrift.LIST},
+		},
+	},
+}
+
+func TestProtocols(t *testing.T) {
+	testProtocolReadWriteValues(t, "binary", &thrift.BinaryProtocol{})
+	testProtocolReadWriteValues(t, "binary(non-strict)", &thrift.BinaryProtocol{NonStrict: true})
+	testProtocolReadWriteValues(t, "compact", &thrift.CompactProtocol{})
+}
+
+func testProtocolReadWriteValues(t *testing.T, name string, proto thrift.Protocol) {
+	for _, test := range protocolReadWriteTests {
+		t.Run(name+"/"+test.scenario, func(t *testing.T) {
+			bb := new(bytes.Buffer)
+			rb := bufio.NewReader(bb)
+			wb := bufio.NewWriter(bb)
+
+			r := proto.NewReader(rb)
+			w := proto.NewWriter(wb)
+
+			for _, value := range test.values {
+				ret := reflect.ValueOf(test.write).Call([]reflect.Value{
+					reflect.ValueOf(w),
+					reflect.ValueOf(value),
+				})
+				if err, _ := ret[0].Interface().(error); err != nil {
+					t.Fatal("encoding:", err)
+				}
+			}
+
+			wb.Flush()
+
+			for _, value := range test.values {
+				ret := reflect.ValueOf(test.read).Call([]reflect.Value{
+					reflect.ValueOf(r),
+				})
+				if err, _ := ret[1].Interface().(error); err != nil {
+					t.Fatal("decoding:", err)
+				}
+				if res := ret[0].Interface(); !reflect.DeepEqual(value, res) {
+					t.Errorf("value mismatch:\nwant: %#v\ngot:  %#v", value, res)
+				}
+			}
+
+			_, err := rb.Peek(1)
+			if err != io.EOF {
+				t.Errorf("unexpected error after reading all values: %v", err)
+			}
+		})
+	}
+}

--- a/thrift/struct.go
+++ b/thrift/struct.go
@@ -34,7 +34,7 @@ func forEachStructField(t reflect.Type, index []int, do func(structField)) {
 	for i, n := 0, t.NumField(); i < n; i++ {
 		f := t.Field(i)
 
-		if !f.IsExported() {
+		if f.PkgPath != "" { // unexported
 			continue
 		}
 

--- a/thrift/struct.go
+++ b/thrift/struct.go
@@ -10,15 +10,20 @@ import (
 type flags int16
 
 const (
-	noflags  flags = 0
 	enum     flags = 1 << 0
 	union    flags = 1 << 1
 	required flags = 1 << 2
 	optional flags = 1 << 3
 	strict   flags = 1 << 4
 
-	structFlags flags = enum | union | required | optional
-	decodeFlags flags = strict
+	featuresBitOffset  = 8
+	useDeltaEncoding   = flags(UseDeltaEncoding) << featuresBitOffset
+	coalesceBoolFields = flags(CoalesceBoolFields) << featuresBitOffset
+
+	structFlags   flags = enum | union | required | optional
+	encodeFlags   flags = strict | protocolFlags
+	decodeFlags   flags = strict | protocolFlags
+	protocolFlags flags = useDeltaEncoding | coalesceBoolFields
 )
 
 func (f flags) have(x flags) bool {

--- a/thrift/struct.go
+++ b/thrift/struct.go
@@ -15,14 +15,26 @@ const (
 	union    flags = 1 << 1
 	required flags = 1 << 2
 	optional flags = 1 << 3
+	strict   flags = 1 << 4
+
+	structFlags flags = enum | union | required | optional
+	decodeFlags flags = strict
 )
 
 func (f flags) have(x flags) bool {
 	return (f & x) == x
 }
 
+func (f flags) only(x flags) flags {
+	return f & x
+}
+
 func (f flags) with(x flags) flags {
 	return f | x
+}
+
+func (f flags) without(x flags) flags {
+	return f & ^x
 }
 
 type structField struct {

--- a/thrift/struct.go
+++ b/thrift/struct.go
@@ -53,7 +53,7 @@ func forEachStructField(t reflect.Type, index []int, do func(structField)) {
 	for i, n := 0, t.NumField(); i < n; i++ {
 		f := t.Field(i)
 
-		if f.PkgPath != "" { // unexported
+		if f.PkgPath != "" && !f.Anonymous { // unexported
 			continue
 		}
 

--- a/thrift/struct.go
+++ b/thrift/struct.go
@@ -1,0 +1,35 @@
+package thrift
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+)
+
+func forEachStructField(t reflect.Type, index []int, do func(reflect.Type, int16, []int)) {
+	for i, n := 0, t.NumField(); i < n; i++ {
+		f := t.Field(i)
+
+		if !f.IsExported() {
+			continue
+		}
+
+		fieldIndex := append(index, i)
+		fieldIndex = fieldIndex[:len(fieldIndex):len(fieldIndex)]
+
+		if f.Anonymous && f.Type.Kind() == reflect.Struct {
+			forEachStructField(f.Type, fieldIndex, do)
+			continue
+		}
+
+		if tag := f.Tag.Get("thrift"); tag == "" {
+			continue
+		} else if id, err := strconv.ParseInt(tag, 10, 16); err != nil {
+			panic(fmt.Errorf("invalid thrift field id found in struct tag: %w", err))
+		} else if id <= 0 {
+			panic(fmt.Errorf("invalid thrift field id found in struct tag: %d <= 0", id))
+		} else {
+			do(f.Type, int16(id), fieldIndex)
+		}
+	}
+}

--- a/thrift/struct.go
+++ b/thrift/struct.go
@@ -10,9 +10,10 @@ import (
 type flags int16
 
 const (
-	noflags flags = 0
-	enum    flags = 1 << 0
-	union   flags = 1 << 1
+	noflags  flags = 0
+	enum     flags = 1 << 0
+	union    flags = 1 << 1
+	required flags = 1 << 2
 )
 
 func (f flags) have(x flags) bool {
@@ -59,6 +60,8 @@ func forEachStructField(t reflect.Type, index []int, do func(structField)) {
 				flags = flags.with(enum)
 			case "union":
 				flags = flags.with(union)
+			case "required":
+				flags = flags.with(required)
 			}
 		}
 

--- a/thrift/thrift.go
+++ b/thrift/thrift.go
@@ -93,6 +93,10 @@ func (t Type) String() string {
 	}
 }
 
+func (t Type) GoString() string {
+	return "thrift." + t.String()
+}
+
 type List struct {
 	Size int32
 	Type Type

--- a/thrift/thrift.go
+++ b/thrift/thrift.go
@@ -1,5 +1,10 @@
 package thrift
 
+import (
+	"fmt"
+	"reflect"
+)
+
 type Message struct {
 	Type  MessageType
 	Name  string
@@ -15,9 +20,28 @@ const (
 	Oneway
 )
 
+func (m MessageType) String() string {
+	switch m {
+	case Call:
+		return "Call"
+	case Reply:
+		return "Reply"
+	case Exception:
+		return "Exception"
+	case Oneway:
+		return "Oneway"
+	default:
+		return "?"
+	}
+}
+
 type Field struct {
 	ID   int16
 	Type Type
+}
+
+func (f Field) String() string {
+	return fmt.Sprintf("FIELD<%s>(%d)", f.Type, f.ID)
 }
 
 type Type int8
@@ -38,13 +62,93 @@ const (
 	BOOL = FALSE
 )
 
+func (t Type) String() string {
+	switch t {
+	case TRUE, FALSE:
+		return "BOOL"
+	case I8:
+		return "I8"
+	case I16:
+		return "I16"
+	case I32:
+		return "I32"
+	case I64:
+		return "I64"
+	case DOUBLE:
+		return "DOUBLE"
+	case BINARY:
+		return "BINARY"
+	case LIST:
+		return "LIST"
+	case SET:
+		return "SET"
+	case MAP:
+		return "MAP"
+	case STRUCT:
+		return "STRUCT"
+	default:
+		return "?"
+	}
+}
+
 type List struct {
 	Size int32
 	Type Type
+}
+
+func (l List) String() string {
+	return fmt.Sprintf("LIST<%s>(%d)", l.Type, l.Size)
+}
+
+type Set List
+
+func (s Set) String() string {
+	return fmt.Sprintf("SET<%s>(%d)", s.Type, s.Size)
 }
 
 type Map struct {
 	Size  int32
 	Key   Type
 	Value Type
+}
+
+func (m Map) String() string {
+	return fmt.Sprintf("MAP<%s,%s>(%d)", m.Key, m.Value, m.Size)
+}
+
+func TypeOf(t reflect.Type) Type {
+	switch t.Kind() {
+	case reflect.Bool:
+		return BOOL
+	case reflect.Int8, reflect.Uint8:
+		return I8
+	case reflect.Int16, reflect.Uint16:
+		return I16
+	case reflect.Int32, reflect.Uint32:
+		return I32
+	case reflect.Int64, reflect.Uint64, reflect.Int, reflect.Uint, reflect.Uintptr:
+		return I64
+	case reflect.Float32, reflect.Float64:
+		return DOUBLE
+	case reflect.String:
+		return BINARY
+	case reflect.Slice:
+		if t.Elem().Kind() == reflect.Uint8 { // []byte
+			return BINARY
+		} else {
+			return LIST
+		}
+	case reflect.Map:
+		if t.Elem().Size() == 0 {
+			return SET
+		} else {
+			return MAP
+		}
+	case reflect.Struct:
+		return STRUCT
+	case reflect.Ptr:
+		return TypeOf(t.Elem())
+	default:
+		panic("type cannot be represented in thrift: " + t.String())
+	}
 }

--- a/thrift/thrift.go
+++ b/thrift/thrift.go
@@ -36,8 +36,9 @@ func (m MessageType) String() string {
 }
 
 type Field struct {
-	ID   int16
-	Type Type
+	ID    int16
+	Type  Type
+	Delta bool // whether the field id is a delta
 }
 
 func (f Field) String() string {
@@ -47,7 +48,8 @@ func (f Field) String() string {
 type Type int8
 
 const (
-	TRUE Type = iota + 1
+	STOP Type = iota
+	TRUE
 	FALSE
 	I8
 	I16
@@ -64,6 +66,8 @@ const (
 
 func (t Type) String() string {
 	switch t {
+	case STOP:
+		return "STOP"
 	case TRUE:
 		return "TRUE"
 	case BOOL:

--- a/thrift/thrift.go
+++ b/thrift/thrift.go
@@ -64,7 +64,9 @@ const (
 
 func (t Type) String() string {
 	switch t {
-	case TRUE, FALSE:
+	case TRUE:
+		return "TRUE"
+	case BOOL:
 		return "BOOL"
 	case I8:
 		return "I8"

--- a/thrift/thrift.go
+++ b/thrift/thrift.go
@@ -41,7 +41,7 @@ type Field struct {
 }
 
 func (f Field) String() string {
-	return fmt.Sprintf("FIELD<%s>(%d)", f.Type, f.ID)
+	return fmt.Sprintf("%d:FIELD<%s>", f.ID, f.Type)
 }
 
 type Type int8
@@ -99,13 +99,13 @@ type List struct {
 }
 
 func (l List) String() string {
-	return fmt.Sprintf("LIST<%s>(%d)", l.Type, l.Size)
+	return fmt.Sprintf("LIST<%s>", l.Type)
 }
 
 type Set List
 
 func (s Set) String() string {
-	return fmt.Sprintf("SET<%s>(%d)", s.Type, s.Size)
+	return fmt.Sprintf("SET<%s>", s.Type)
 }
 
 type Map struct {
@@ -115,7 +115,7 @@ type Map struct {
 }
 
 func (m Map) String() string {
-	return fmt.Sprintf("MAP<%s,%s>(%d)", m.Key, m.Value, m.Size)
+	return fmt.Sprintf("MAP<%s,%s>", m.Key, m.Value)
 }
 
 func TypeOf(t reflect.Type) Type {

--- a/thrift/thrift.go
+++ b/thrift/thrift.go
@@ -1,0 +1,50 @@
+package thrift
+
+type Message struct {
+	Type  MessageType
+	Name  string
+	SeqID int32
+}
+
+type MessageType int8
+
+const (
+	Call MessageType = iota
+	Reply
+	Exception
+	Oneway
+)
+
+type Field struct {
+	ID   int16
+	Type Type
+}
+
+type Type int8
+
+const (
+	TRUE Type = iota + 1
+	FALSE
+	I8
+	I16
+	I32
+	I64
+	DOUBLE
+	BINARY
+	LIST
+	SET
+	MAP
+	STRUCT
+	BOOL = FALSE
+)
+
+type List struct {
+	Size int32
+	Type Type
+}
+
+type Map struct {
+	Size  int32
+	Key   Type
+	Value Type
+}

--- a/thrift/thrift_test.go
+++ b/thrift/thrift_test.go
@@ -212,6 +212,16 @@ var marshalTestValues = [...]struct {
 			StructWithEnum{Enum: 2},
 		},
 	},
+
+	{
+		scenario: "StructWithUnion",
+		values: []interface{}{
+			StructWithUnion{},
+			StructWithUnion{Union: Union{A: true}},
+			StructWithUnion{Union: Union{B: 42}},
+			StructWithUnion{Union: Union{C: "hello world!"}},
+		},
+	},
 }
 
 type Point2D struct {
@@ -226,6 +236,16 @@ type RecursiveStruct struct {
 
 type StructWithEnum struct {
 	Enum int8 `thrift:"1,enum"`
+}
+
+type StructWithUnion struct {
+	Union Union `thrift:"1,union"`
+}
+
+type Union struct {
+	A bool   `thrift:"1"`
+	B int    `thrift:"2"`
+	C string `thrift:"3"`
 }
 
 func TestMarshalUnmarshal(t *testing.T) {

--- a/thrift/thrift_test.go
+++ b/thrift/thrift_test.go
@@ -214,12 +214,12 @@ var marshalTestValues = [...]struct {
 	},
 
 	{
-		scenario: "StructWithUnion",
+		scenario: "Union",
 		values: []interface{}{
-			StructWithUnion{},
-			StructWithUnion{Union: Union{A: true}},
-			StructWithUnion{Union: Union{B: 42}},
-			StructWithUnion{Union: Union{C: "hello world!"}},
+			Union{},
+			Union{A: true, F: newBool(true)},
+			Union{B: 42, F: newInt(42)},
+			Union{C: "hello world!", F: newString("hello world!")},
 		},
 	},
 }
@@ -238,15 +238,16 @@ type StructWithEnum struct {
 	Enum int8 `thrift:"1,enum"`
 }
 
-type StructWithUnion struct {
-	Union Union `thrift:"1,union"`
+type Union struct {
+	A bool        `thrift:"1"`
+	B int         `thrift:"2"`
+	C string      `thrift:"3"`
+	F interface{} `thrift:",union"`
 }
 
-type Union struct {
-	A bool   `thrift:"1"`
-	B int    `thrift:"2"`
-	C string `thrift:"3"`
-}
+func newBool(b bool) *bool       { return &b }
+func newInt(i int) *int          { return &i }
+func newString(s string) *string { return &s }
 
 func TestMarshalUnmarshal(t *testing.T) {
 	for _, p := range protocols {

--- a/thrift/thrift_test.go
+++ b/thrift/thrift_test.go
@@ -73,58 +73,6 @@ var marshalTestValues = [...]struct {
 	},
 
 	{
-		scenario: "uint",
-		values: []interface{}{
-			uint(0),
-			uint(1),
-		},
-	},
-
-	{
-		scenario: "uint8",
-		values: []interface{}{
-			uint8(0),
-			uint8(1),
-			uint8(math.MaxUint8),
-		},
-	},
-
-	{
-		scenario: "uint16",
-		values: []interface{}{
-			uint16(0),
-			uint16(1),
-			uint16(math.MaxUint16),
-		},
-	},
-
-	{
-		scenario: "uint32",
-		values: []interface{}{
-			uint32(0),
-			uint32(1),
-			uint32(math.MaxUint32),
-		},
-	},
-
-	{
-		scenario: "uint64",
-		values: []interface{}{
-			uint64(0),
-			uint64(1),
-			uint64(math.MaxUint64),
-		},
-	},
-
-	{
-		scenario: "uintptr",
-		values: []interface{}{
-			uintptr(0),
-			uintptr(1),
-		},
-	},
-
-	{
 		scenario: "string",
 		values: []interface{}{
 			"",

--- a/thrift/thrift_test.go
+++ b/thrift/thrift_test.go
@@ -225,8 +225,8 @@ var marshalTestValues = [...]struct {
 }
 
 type Point2D struct {
-	X float64 `thrift:"1"`
-	Y float64 `thrift:"2"`
+	X float64 `thrift:"1,required"`
+	Y float64 `thrift:"2,required"`
 }
 
 type RecursiveStruct struct {

--- a/thrift/thrift_test.go
+++ b/thrift/thrift_test.go
@@ -203,6 +203,15 @@ var marshalTestValues = [...]struct {
 			RecursiveStruct{Value: "hello", Next: &RecursiveStruct{Value: "world"}},
 		},
 	},
+
+	{
+		scenario: "StructWithEnum",
+		values: []interface{}{
+			StructWithEnum{},
+			StructWithEnum{Enum: 1},
+			StructWithEnum{Enum: 2},
+		},
+	},
 }
 
 type Point2D struct {
@@ -213,6 +222,10 @@ type Point2D struct {
 type RecursiveStruct struct {
 	Value string           `thrift:"1"`
 	Next  *RecursiveStruct `thrift:"2"`
+}
+
+type StructWithEnum struct {
+	Enum int8 `thrift:"1,enum"`
 }
 
 func TestMarshalUnmarshal(t *testing.T) {

--- a/thrift/thrift_test.go
+++ b/thrift/thrift_test.go
@@ -1,0 +1,316 @@
+package thrift_test
+
+import (
+	"bytes"
+	"math"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/segmentio/encoding/thrift"
+)
+
+var marshalTestValues = [...]struct {
+	scenario string
+	values   []interface{}
+}{
+	{
+		scenario: "bool",
+		values:   []interface{}{false, true},
+	},
+
+	{
+		scenario: "int",
+		values: []interface{}{
+			int(0),
+			int(-1),
+			int(1),
+		},
+	},
+
+	{
+		scenario: "int8",
+		values: []interface{}{
+			int8(0),
+			int8(-1),
+			int8(1),
+			int8(math.MinInt8),
+			int8(math.MaxInt8),
+		},
+	},
+
+	{
+		scenario: "int16",
+		values: []interface{}{
+			int16(0),
+			int16(-1),
+			int16(1),
+			int16(math.MinInt16),
+			int16(math.MaxInt16),
+		},
+	},
+
+	{
+		scenario: "int32",
+		values: []interface{}{
+			int32(0),
+			int32(-1),
+			int32(1),
+			int32(math.MinInt32),
+			int32(math.MaxInt32),
+		},
+	},
+
+	{
+		scenario: "int64",
+		values: []interface{}{
+			int64(0),
+			int64(-1),
+			int64(1),
+			int64(math.MinInt64),
+			int64(math.MaxInt64),
+		},
+	},
+
+	{
+		scenario: "uint",
+		values: []interface{}{
+			uint(0),
+			uint(1),
+		},
+	},
+
+	{
+		scenario: "uint8",
+		values: []interface{}{
+			uint8(0),
+			uint8(1),
+			uint8(math.MaxUint8),
+		},
+	},
+
+	{
+		scenario: "uint16",
+		values: []interface{}{
+			uint16(0),
+			uint16(1),
+			uint16(math.MaxUint16),
+		},
+	},
+
+	{
+		scenario: "uint32",
+		values: []interface{}{
+			uint32(0),
+			uint32(1),
+			uint32(math.MaxUint32),
+		},
+	},
+
+	{
+		scenario: "uint64",
+		values: []interface{}{
+			uint64(0),
+			uint64(1),
+			uint64(math.MaxUint64),
+		},
+	},
+
+	{
+		scenario: "uintptr",
+		values: []interface{}{
+			uintptr(0),
+			uintptr(1),
+		},
+	},
+
+	{
+		scenario: "string",
+		values: []interface{}{
+			"",
+			"A",
+			"1234567890",
+			strings.Repeat("qwertyuiop", 100),
+		},
+	},
+
+	{
+		scenario: "[]byte",
+		values: []interface{}{
+			[]byte(""),
+			[]byte("A"),
+			[]byte("1234567890"),
+			bytes.Repeat([]byte("qwertyuiop"), 100),
+		},
+	},
+
+	{
+		scenario: "[]string",
+		values: []interface{}{
+			[]string{},
+			[]string{"A"},
+			[]string{"hello", "world", "!!!"},
+			[]string{"0", "1", "3", "4", "5", "6", "7", "8", "9"},
+		},
+	},
+
+	{
+		scenario: "map[string]int",
+		values: []interface{}{
+			map[string]int{},
+			map[string]int{"A": 1},
+			map[string]int{"hello": 1, "world": 2, "answer": 42},
+		},
+	},
+
+	{
+		scenario: "map[int64]struct{}",
+		values: []interface{}{
+			map[int64]struct{}{},
+			map[int64]struct{}{0: {}, 1: {}, 2: {}},
+		},
+	},
+
+	{
+		scenario: "[]map[string]struct{}",
+		values: []interface{}{
+			[]map[string]struct{}{},
+			[]map[string]struct{}{{}, {"A": {}, "B": {}, "C": {}}},
+		},
+	},
+
+	{
+		scenario: "struct{}",
+		values:   []interface{}{struct{}{}},
+	},
+
+	{
+		scenario: "Point2D",
+		values: []interface{}{
+			Point2D{},
+			Point2D{X: 1},
+			Point2D{Y: 2},
+			Point2D{X: 3, Y: 4},
+		},
+	},
+
+	{
+		scenario: "RecursiveStruct",
+		values: []interface{}{
+			RecursiveStruct{},
+			RecursiveStruct{Value: "hello"},
+			RecursiveStruct{Value: "hello", Next: &RecursiveStruct{}},
+			RecursiveStruct{Value: "hello", Next: &RecursiveStruct{Value: "world"}},
+		},
+	},
+}
+
+type Point2D struct {
+	X float64 `thrift:"1"`
+	Y float64 `thrift:"2"`
+}
+
+type RecursiveStruct struct {
+	Value string           `thrift:"1"`
+	Next  *RecursiveStruct `thrift:"2"`
+}
+
+func TestMarshalUnmarshal(t *testing.T) {
+	for _, p := range protocols {
+		t.Run(p.name, func(t *testing.T) { testMarshalUnmarshal(t, p.proto) })
+	}
+}
+
+func testMarshalUnmarshal(t *testing.T, p thrift.Protocol) {
+	for _, test := range marshalTestValues {
+		t.Run(test.scenario, func(t *testing.T) {
+			for _, value := range test.values {
+				b, err := thrift.Marshal(p, value)
+				if err != nil {
+					t.Fatal("marshal:", err)
+				}
+
+				v := reflect.New(reflect.TypeOf(value))
+				if err := thrift.Unmarshal(p, b, v.Interface()); err != nil {
+					t.Fatal("unmarshal:", err)
+				}
+
+				if result := v.Elem().Interface(); !reflect.DeepEqual(value, result) {
+					t.Errorf("value mismatch:\nwant: %#v\ngot:  %#v", value, result)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkMarshal(b *testing.B) {
+	for _, p := range protocols {
+		b.Run(p.name, func(b *testing.B) { benchmarkMarshal(b, p.proto) })
+	}
+}
+
+type BenchmarkEncodeType struct {
+	Name     string               `thrift:"1"`
+	Question string               `thrift:"2"`
+	Answer   string               `thrift:"3"`
+	Sub      *BenchmarkEncodeType `thrift:"4"`
+}
+
+func benchmarkMarshal(b *testing.B, p thrift.Protocol) {
+	buf := new(bytes.Buffer)
+	enc := thrift.NewEncoder(p.NewWriter(buf))
+	val := &BenchmarkEncodeType{
+		Name:     "Luke",
+		Question: "How are you?",
+		Answer:   "42",
+		Sub: &BenchmarkEncodeType{
+			Name:     "Leia",
+			Question: "?",
+			Answer:   "whatever",
+		},
+	}
+
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		enc.Encode(val)
+	}
+
+	b.SetBytes(int64(buf.Len()))
+}
+
+func BenchmarkUnmarshal(b *testing.B) {
+	for _, p := range protocols {
+		b.Run(p.name, func(b *testing.B) { benchmarkUnmarshal(b, p.proto) })
+	}
+}
+
+type BenchmarkDecodeType struct {
+	Name     string               `thrift:"1"`
+	Question string               `thrift:"2"`
+	Answer   string               `thrift:"3"`
+	Sub      *BenchmarkDecodeType `thrift:"4"`
+}
+
+func benchmarkUnmarshal(b *testing.B, p thrift.Protocol) {
+	buf, _ := thrift.Marshal(p, &BenchmarkDecodeType{
+		Name:     "Luke",
+		Question: "How are you?",
+		Answer:   "42",
+		Sub: &BenchmarkDecodeType{
+			Name:     "Leia",
+			Question: "?",
+			Answer:   "whatever",
+		},
+	})
+
+	rb := bytes.NewReader(nil)
+	dec := thrift.NewDecoder(p.NewReader(rb))
+	val := &BenchmarkDecodeType{}
+
+	for i := 0; i < b.N; i++ {
+		rb.Reset(buf)
+		dec.Decode(val)
+	}
+
+	b.SetBytes(int64(len(buf)))
+}

--- a/thrift/unsafe.go
+++ b/thrift/unsafe.go
@@ -1,0 +1,20 @@
+package thrift
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+// typeID is used as key in encoder and decoder caches to enable using
+// the optimize runtime.mapaccess2_fast64 function instead of the more
+// expensive lookup if we were to use reflect.Type as map key.
+//
+// typeID holds the pointer to the reflect.Type value, which is unique
+// in the program.
+type typeID struct{ ptr unsafe.Pointer }
+
+func makeTypeID(t reflect.Type) typeID {
+	return typeID{
+		ptr: (*[2]unsafe.Pointer)(unsafe.Pointer(&t))[1],
+	}
+}

--- a/thrift/unsafe.go
+++ b/thrift/unsafe.go
@@ -18,3 +18,7 @@ func makeTypeID(t reflect.Type) typeID {
 		ptr: (*[2]unsafe.Pointer)(unsafe.Pointer(&t))[1],
 	}
 }
+
+func unsafeBytesToString(b []byte) string {
+	return *(*string)(unsafe.Pointer(&b))
+}


### PR DESCRIPTION
This PR adds a new package implementing encoders and decoders for the thrift protocols.

I based the implementation on these documents (plus some reverse-engineering):
* [Thrift Binary protocol encoding](https://github.com/apache/thrift/blob/master/doc/specs/thrift-binary-protocol.md)
* [Thrift Compact protocol encoding](https://github.com/apache/thrift/blob/master/doc/specs/thrift-compact-protocol.md#integer-encoding)

A did a couple of rounds of profiling to optimize low hanging fruits, here's a snapshot of the benchmark results:

```
goos: darwin
goarch: amd64
pkg: github.com/segmentio/encoding/thrift
cpu: Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
BenchmarkMarshal
BenchmarkMarshal/binary(default)
BenchmarkMarshal/binary(default)         	 6901712	       344.0 ns/op	 238.35 MB/s	       0 B/op	       0 allocs/op
BenchmarkMarshal/binary(non-strict)
BenchmarkMarshal/binary(non-strict)      	 6945897	       345.7 ns/op	 237.21 MB/s	       0 B/op	       0 allocs/op
BenchmarkMarshal/compact
BenchmarkMarshal/compact                 	 7083963	       328.9 ns/op	 142.90 MB/s	       0 B/op	       0 allocs/op
BenchmarkUnmarshal
BenchmarkUnmarshal/binary(default)
BenchmarkUnmarshal/binary(default)       	 4117336	       567.1 ns/op	 144.58 MB/s	      96 B/op	       6 allocs/op
BenchmarkUnmarshal/binary(non-strict)
BenchmarkUnmarshal/binary(non-strict)    	 4227864	       566.3 ns/op	 144.79 MB/s	      96 B/op	       6 allocs/op
BenchmarkUnmarshal/compact
BenchmarkUnmarshal/compact               	 4731031	       496.3 ns/op	  94.69 MB/s	      96 B/op	       6 allocs/op
PASS
ok  	github.com/segmentio/encoding/thrift	17.076s
```

This is a first pass, there are probably bugs and room for improvements. I also did not add any mechanism to support extensions like there are for JSON via `json.Marshaler`/`json.Unmarshaler`, this is work left to do in the future when we need it.