### PR TITLE
fix: fix some proto decode error

### DIFF
--- a/internal/runtime_reflect/slice.go
+++ b/internal/runtime_reflect/slice.go
@@ -39,6 +39,6 @@ func CopySlice(elemType unsafe.Pointer, dst, src Slice) int {
 //go:linkname newarray runtime.newarray
 func newarray(t unsafe.Pointer, n int) unsafe.Pointer
 
-//go:linkname typedslicecopy runtime.typedslicecopy
+//go:linkname typedslicecopy reflect.typedslicecopy
 //go:noescape
 func typedslicecopy(t unsafe.Pointer, dst, src Slice) int

--- a/proto/int32.go
+++ b/proto/int32.go
@@ -1,8 +1,6 @@
 package proto
 
 import (
-	"fmt"
-	"math"
 	"unsafe"
 )
 
@@ -33,10 +31,6 @@ func encodeInt32(b []byte, p unsafe.Pointer, flags flags) (int, error) {
 
 func decodeInt32(b []byte, p unsafe.Pointer, flags flags) (int, error) {
 	u, n, err := decodeVarint(b)
-	v := flags.int64(u)
-	if v < math.MinInt32 || v > math.MaxInt32 {
-		return n, fmt.Errorf("integer overflow decoding %v into int32", v)
-	}
-	*(*int32)(p) = int32(v)
+	*(*int32)(p) = int32(flags.int64(u))
 	return n, err
 }


### PR DESCRIPTION
I used to use module "google.golang.org/protobuf",  when I switch to this module I found it can't decode `-1` to int32 while this is permitted in "google.golang.org/protobuf". To make it compatible with that package, we should drop this overflow checking.

Also I found a function linkname to a wrong function. If we pass a dst slice whose cap is zero, it will crash with a nil pointer direference error.