### PR TITLE
add test for issue 107

### DIFF
--- a/json/json.go
+++ b/json/json.go
@@ -55,7 +55,7 @@ type UnsupportedValueError = json.UnsupportedValueError
 
 // AppendFlags is a type used to represent configuration options that can be
 // applied when formatting json output.
-type AppendFlags uint
+type AppendFlags uint32
 
 const (
 	// EscapeHTML is a formatting flag used to to escape HTML in json strings.
@@ -74,7 +74,7 @@ const (
 
 // ParseFlags is a type used to represent configuration options that can be
 // applied when parsing json input.
-type ParseFlags uint
+type ParseFlags uint32
 
 func (flags ParseFlags) has(f ParseFlags) bool {
 	return (flags & f) != 0

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1591,6 +1591,26 @@ func TestGithubIssue44(t *testing.T) {
 	}
 }
 
+type issue107Foo struct {
+	Bar *issue107Bar
+}
+
+type issue107Bar struct {
+	Foo *issue107Foo
+}
+
+func TestGithubIssue107(t *testing.T) {
+	f := &issue107Foo{}
+	b := &issue107Bar{}
+	f.Bar = b
+	b.Foo = f
+
+	_, err := Marshal(f) // must not crash
+	if err == nil {
+		t.Error("marshaling a cycling data structure was expected to return an error")
+	}
+}
+
 type rawJsonString string
 
 func (r *rawJsonString) UnmarshalJSON(b []byte) error {

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1606,8 +1606,10 @@ func TestGithubIssue107(t *testing.T) {
 	b.Foo = f
 
 	_, err := Marshal(f) // must not crash
-	if err == nil {
-		t.Error("marshaling a cycling data structure was expected to return an error")
+	switch err.(type) {
+	case *UnsupportedValueError:
+	default:
+		t.Errorf("marshaling a cycling data structure was expected to return an unsupported value error but got %T", err)
 	}
 }
 


### PR DESCRIPTION
Fixes #107 

I've added a pointer cycle check similar to the one used in the standard library, which starts detecting pointer cycles after entering the `encoderPointer` function code 1000 times, which keeps the cost of detecting the loop almost zero in most cases.

I changed the type of `json.AppendFlags` from `uint` to `uint32` so we could store the encoder depth in the other 4 bytes and keep the struct size small. There is an extra pointer we have to store in the encoder tho for the map we might use to track pointer cycles.

I changed the type of `json.ParseFlags` from `uint` to `uint32` for consistency with `json.AppendFlags`.