### PR TITLE
purego fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ go-fuzz-build := ${GOPATH}/bin/go-fuzz-build
 go-fuzz-corpus := ${GOPATH}/src/github.com/dvyukov/go-fuzz-corpus
 go-fuzz-dep := ${GOPATH}/src/github.com/dvyukov/go-fuzz/go-fuzz-dep
 
-test: test-ascii test-json test-json-bugs test-json-1.17 test-proto test-iso8601 test-thrift
+test: test-ascii test-json test-json-bugs test-json-1.17 test-proto test-iso8601 test-thrift test-purego
 
 test-ascii:
 	go test -cover -race ./ascii
@@ -32,6 +32,9 @@ test-iso8601:
 
 test-thrift:
 	go test -cover -race ./thrift
+
+test-purego:
+	go test -race -tags purego ./...
 
 $(benchstat):
 	GO111MODULE=off go get -u golang.org/x/perf/cmd/benchstat

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/segmentio/encoding
 
 go 1.14
 
-require github.com/segmentio/asm v1.1.0
+require github.com/segmentio/asm v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/klauspost/cpuid/v2 v2.0.6 h1:dQ5ueTiftKxp0gyjKSx5+8BtPWkyQbd95m8Gys/RarI=
-github.com/klauspost/cpuid/v2 v2.0.6/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
-github.com/segmentio/asm v1.1.0 h1:fkVr8k5J4sKoFjTGVD6r1yKvDKqmvrEh3K7iyVxgBs8=
-github.com/segmentio/asm v1.1.0/go.mod h1:4EUJGaKsB8ImLUwOGORVsNd9vTRDeh44JGsY4aKp5I4=
+github.com/segmentio/asm v1.1.2 h1:AqF5GZe7ea+STIn7wnhPZJ0RANYndrphebwtOmceahw=
+github.com/segmentio/asm v1.1.2/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
+golang.org/x/sys v0.0.0-20211110154304-99a53858aa08 h1:WecRHqgE09JBkh/584XIE6PMz5KKE/vER4izNUi30AQ=
+golang.org/x/sys v0.0.0-20211110154304-99a53858aa08/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
This PR fixes the following `go test -race -tags purego` issue:

```
fatal error: checkptr: pointer arithmetic result points to invalid allocation

goroutine 35 [running]:
runtime.throw({0x1010ceb85, 0x40})
	runtime/panic.go:1198 +0x54 fp=0xc00004cb00 sp=0xc00004cad0 pc=0x100f81794
runtime.checkptrArithmetic(0xc00016a040, {0xc00004cb90, 0x1, 0x1})
	runtime/checkptr.go:69 +0xbc fp=0xc00004cb30 sp=0xc00004cb00 pc=0x100f5106c
github.com/segmentio/asm/ascii.ValidPrintString({0xc00016a020, 0x20})
	github.com/segmentio/asm@v1.1.0/ascii/valid_print_default.go:16 +0x80 fp=0xc00004cba0 sp=0xc00004cb30 pc=0x101092be0
github.com/segmentio/asm/ascii.ValidPrint(...)
	github.com/segmentio/asm@v1.1.0/ascii/valid_print.go:7
github.com/segmentio/encoding/ascii.ValidPrint(...)
```

See https://github.com/segmentio/asm/pull/64.