### PR TITLE
Optimize short string parsing (part 2)

### DIFF
--- a/json/parse.go
+++ b/json/parse.go
@@ -439,25 +439,33 @@ func (d decoder) parseString(b []byte) ([]byte, []byte, Kind, error) {
 
 	var n int
 	if len(b) >= 9 {
-		// This is an optimization for short strings. We read 8 bytes,
+		// This is an optimization for short strings. We read 8/16 bytes,
 		// and XOR each with 0x22 (") so that these bytes (and only
 		// these bytes) are now zero. We use the hasless(u,1) trick
 		// from https://graphics.stanford.edu/~seander/bithacks.html#ZeroInWord
 		// to determine whether any bytes are zero. Finally, we CTZ
 		// to find the index of that byte.
-		u := binary.LittleEndian.Uint64(b[1:])
-		u ^= 0x2222222222222222
-		mask := (u - 0x0101010101010101) & ^u & 0x8080808080808080
-		if mask != 0 {
+		const mask1 = 0x2222222222222222
+		const mask2 = 0x0101010101010101
+		const mask3 = 0x8080808080808080
+		u := binary.LittleEndian.Uint64(b[1:]) ^ mask1
+		if mask := (u - mask2) & ^u & mask3; mask != 0 {
 			n = bits.TrailingZeros64(mask)/8 + 2
 			goto found
 		}
+		if len(b) >= 17 {
+			u = binary.LittleEndian.Uint64(b[9:]) ^ mask1
+			if mask := (u - mask2) & ^u & mask3; mask != 0 {
+				n = bits.TrailingZeros64(mask)/8 + 10
+				goto found
+			}
+		}
 	}
 	n = bytes.IndexByte(b[1:], '"') + 2
-found:
 	if n <= 1 {
 		return nil, b[len(b):], Undefined, syntaxError(b, "missing '\"' at the end of a string value")
 	}
+found:
 	if (d.flags.has(noBackslash) || bytes.IndexByte(b[1:n], '\\') < 0) &&
 		(d.flags.has(validAsciiPrint) || ascii.ValidPrint(b[1:n])) {
 		return b[:n], b[n:], Unescaped, nil


### PR DESCRIPTION
This PR extends #76 so that we check an extra 8 bytes. With #76 we only take the fast path for strings <= 7 bytes (where the quote is in the 8th byte). The fast path now covers strings of up to 15 bytes.

Parsing longer strings takes a bit of a hit, but I think overall it's a net win given the prevalence of short strings in object keys. I'm also finding that `bytes.IndexByte` is comparatively slower on arm64, so if we can avoid that with some extra bitwise operations then it's a win for our use cases.

amd64:

```
name                             old time/op   new time/op   delta
Unmarshal/*json.codeResponse2-4   4.91ms ± 1%   4.89ms ± 1%  -0.48%  (p=0.002 n=20+18)

name                             old speed     new speed     delta
Unmarshal/*json.codeResponse2-4  395MB/s ± 1%  397MB/s ± 1%  +0.48%  (p=0.002 n=20+18)
```

arm64:

```
name                              old time/op   new time/op   delta
Unmarshal/*json.codeResponse2-10   4.43ms ± 0%   4.29ms ± 0%  -3.16%  (p=0.000 n=19+19)

name                              old speed     new speed     delta
Unmarshal/*json.codeResponse2-10  438MB/s ± 0%  452MB/s ± 0%  +3.27%  (p=0.000 n=19+19)
```