### PR TITLE
Improved field lookup for small structs (arm64)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/segmentio/encoding
 
 go 1.14
 
-require github.com/segmentio/asm v1.1.3-0.20211208013735-fe35271d3e6a
+require github.com/segmentio/asm v1.1.3

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/segmentio/encoding
 
 go 1.14
 
-require github.com/segmentio/asm v1.1.2
+require github.com/segmentio/asm v1.1.3-0.20211208013735-fe35271d3e6a

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,4 @@
-github.com/segmentio/asm v1.1.2 h1:AqF5GZe7ea+STIn7wnhPZJ0RANYndrphebwtOmceahw=
-github.com/segmentio/asm v1.1.2/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
-github.com/segmentio/asm v1.1.3-0.20211208013735-fe35271d3e6a h1:oIyAxhrYLerXe0pmSkzN1jQNghOW/d7IXZDBaXmzBwo=
-github.com/segmentio/asm v1.1.3-0.20211208013735-fe35271d3e6a/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
+github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
+github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
 golang.org/x/sys v0.0.0-20211110154304-99a53858aa08 h1:WecRHqgE09JBkh/584XIE6PMz5KKE/vER4izNUi30AQ=
 golang.org/x/sys v0.0.0-20211110154304-99a53858aa08/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/segmentio/asm v1.1.2 h1:AqF5GZe7ea+STIn7wnhPZJ0RANYndrphebwtOmceahw=
 github.com/segmentio/asm v1.1.2/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
+github.com/segmentio/asm v1.1.3-0.20211208013735-fe35271d3e6a h1:oIyAxhrYLerXe0pmSkzN1jQNghOW/d7IXZDBaXmzBwo=
+github.com/segmentio/asm v1.1.3-0.20211208013735-fe35271d3e6a/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
 golang.org/x/sys v0.0.0-20211110154304-99a53858aa08 h1:WecRHqgE09JBkh/584XIE6PMz5KKE/vER4izNUi30AQ=
 golang.org/x/sys v0.0.0-20211110154304-99a53858aa08/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
This PR adds an arm64 port of the optimizations introduced in #101. See https://github.com/segmentio/asm/pull/65.

```
name                              old time/op   new time/op   delta
Unmarshal/*json.codeResponse2-10   4.15ms ± 0%   3.86ms ± 0%  -7.13%  (p=0.000 n=20+18)

name                              old speed     new speed     delta
Unmarshal/*json.codeResponse2-10  467MB/s ± 0%  503MB/s ± 0%  +7.67%  (p=0.000 n=20+18)
```