### PR TITLE
Fixes Bool method comment

### DIFF
--- a/json/token.go
+++ b/json/token.go
@@ -237,13 +237,13 @@ func (t *Tokenizer) pop(expect scope) error {
 // on.
 func (t *Tokenizer) Kind() Kind { return t.flags.kind() }
 
-// String returns a byte slice containing the value of the json string that the
+// Bool returns a byte slice containing the value of the json boolean that the
 // tokenizer is currently pointing at.
 //
 // This method must only be called after checking the kind of the token via a
 // call to Kind.
 //
-// If the tokenizer is not positioned on a string, the behavior is undefined.
+// If the tokenizer is not positioned on a boolean, the behavior is undefined.
 func (t *Tokenizer) Bool() bool { return t.flags.kind() == True }
 
 // Int returns a byte slice containing the value of the json number that the

--- a/json/token.go
+++ b/json/token.go
@@ -237,7 +237,7 @@ func (t *Tokenizer) pop(expect scope) error {
 // on.
 func (t *Tokenizer) Kind() Kind { return t.flags.kind() }
 
-// Bool returns a byte slice containing the value of the json boolean that the
+// Bool returns a bool containing the value of the json boolean that the
 // tokenizer is currently pointing at.
 //
 // This method must only be called after checking the kind of the token via a


### PR DESCRIPTION
It seems the comment was a wrong copy paste of the string method.

Not sure about "returns a byte slice" but it seems to be used on all other similar methods. 