### PR TITLE
thrift: allow reusing struct fields

### DIFF
--- a/thrift/decode.go
+++ b/thrift/decode.go
@@ -16,6 +16,11 @@ import (
 // The function errors if the data in b does not match the type of v.
 //
 // The function panics if v cannot be converted to a thrift representation.
+//
+// As an optimization, the value passed in v may be reused across multiple calls
+// to Unmarshal, allowing the function to reuse objects referenced by pointer
+// fields of struct values. When reusing objects, the application is responsible
+// for resetting the state of v before calling Unmarshal again.
 func Unmarshal(p Protocol, b []byte, v interface{}) error {
 	br := bytes.NewReader(b)
 	pr := p.NewReader(br)

--- a/thrift/decode.go
+++ b/thrift/decode.go
@@ -347,7 +347,6 @@ type structDecoder struct {
 }
 
 func (dec *structDecoder) decode(r Reader, v reflect.Value, flags flags) error {
-	v.Set(dec.zero)
 	flags = flags.only(decodeFlags)
 	coalesceBoolFields := flags.have(coalesceBoolFields)
 


### PR DESCRIPTION
This is a small change to allow reusing inner pointer fields of struct values in the thrift decoder. The existing implementation would always zero out the struct value before decoding it, which means pointers are set to `nil` and whatever object they were referencing is lost.

Most applications won't need this optimization and can allocate new objects to decode values into (they will have the zero value then). Applications that do need this optimization are aware that they must zero-out the objects they reuse across decoding operations, which makes it a meaningful change.