### PR TITLE
Encoder: add SetAddExtraNewline option to json.Encoder

### DIFF
--- a/json/json.go
+++ b/json/json.go
@@ -71,10 +71,10 @@ const (
 	// known to be valid json (e.g., they were created by json.Unmarshal).
 	TrustRawMessage
 
-	// AppendNewline is a formatting flag to enable the addition of a newline
+	// appendNewline is a formatting flag to enable the addition of a newline
 	// in Encode (this matches the behavior of the standard encoding/json
 	// package).
-	AppendNewline
+	appendNewline
 )
 
 // ParseFlags is a type used to represent configuration options that can be
@@ -486,7 +486,7 @@ type Encoder struct {
 
 // NewEncoder is documented at https://golang.org/pkg/encoding/json/#NewEncoder
 func NewEncoder(w io.Writer) *Encoder {
-	return &Encoder{writer: w, flags: EscapeHTML | SortMapKeys | AppendNewline}
+	return &Encoder{writer: w, flags: EscapeHTML | SortMapKeys | appendNewline}
 }
 
 // Encode is documented at https://golang.org/pkg/encoding/json/#Encoder.Encode
@@ -505,7 +505,7 @@ func (enc *Encoder) Encode(v interface{}) error {
 		return err
 	}
 
-	if (enc.flags & AppendNewline) != 0 {
+	if (enc.flags & appendNewline) != 0 {
 		buf.data = append(buf.data, '\n')
 	}
 	b := buf.data
@@ -569,9 +569,9 @@ func (enc *Encoder) SetTrustRawMessage(on bool) {
 // allows the program to toggle the addition of a newline in Encode on or off.
 func (enc *Encoder) SetAppendNewline(on bool) {
 	if on {
-		enc.flags |= AppendNewline
+		enc.flags |= appendNewline
 	} else {
-		enc.flags &= ^AppendNewline
+		enc.flags &= ^appendNewline
 	}
 }
 

--- a/json/json.go
+++ b/json/json.go
@@ -471,16 +471,19 @@ func (dec *Decoder) InputOffset() int64 {
 
 // Encoder is documented at https://golang.org/pkg/encoding/json/#Encoder
 type Encoder struct {
-	writer io.Writer
-	prefix string
-	indent string
-	buffer *bytes.Buffer
-	err    error
-	flags  AppendFlags
+	writer          io.Writer
+	prefix          string
+	indent          string
+	buffer          *bytes.Buffer
+	err             error
+	flags           AppendFlags
+	addExtraNewline bool
 }
 
 // NewEncoder is documented at https://golang.org/pkg/encoding/json/#NewEncoder
-func NewEncoder(w io.Writer) *Encoder { return &Encoder{writer: w, flags: EscapeHTML | SortMapKeys} }
+func NewEncoder(w io.Writer) *Encoder {
+	return &Encoder{writer: w, flags: EscapeHTML | SortMapKeys, addExtraNewline: true}
+}
 
 // Encode is documented at https://golang.org/pkg/encoding/json/#Encoder.Encode
 func (enc *Encoder) Encode(v interface{}) error {
@@ -498,7 +501,9 @@ func (enc *Encoder) Encode(v interface{}) error {
 		return err
 	}
 
-	buf.data = append(buf.data, '\n')
+	if enc.addExtraNewline {
+		buf.data = append(buf.data, '\n')
+	}
 	b := buf.data
 
 	if enc.prefix != "" || enc.indent != "" {
@@ -554,6 +559,12 @@ func (enc *Encoder) SetTrustRawMessage(on bool) {
 	} else {
 		enc.flags &= ^TrustRawMessage
 	}
+}
+
+// SetAddExtraNewline is an extension to the standard encoding/json package which
+// allows the program to toggle the addition of a newline in Encode on or off.
+func (enc *Encoder) SetAddExtraNewline(on bool) {
+	enc.addExtraNewline = on
 }
 
 var encoderBufferPool = sync.Pool{

--- a/json/json.go
+++ b/json/json.go
@@ -471,18 +471,18 @@ func (dec *Decoder) InputOffset() int64 {
 
 // Encoder is documented at https://golang.org/pkg/encoding/json/#Encoder
 type Encoder struct {
-	writer          io.Writer
-	prefix          string
-	indent          string
-	buffer          *bytes.Buffer
-	err             error
-	flags           AppendFlags
-	addExtraNewline bool
+	writer        io.Writer
+	prefix        string
+	indent        string
+	buffer        *bytes.Buffer
+	err           error
+	flags         AppendFlags
+	appendNewline bool
 }
 
 // NewEncoder is documented at https://golang.org/pkg/encoding/json/#NewEncoder
 func NewEncoder(w io.Writer) *Encoder {
-	return &Encoder{writer: w, flags: EscapeHTML | SortMapKeys, addExtraNewline: true}
+	return &Encoder{writer: w, flags: EscapeHTML | SortMapKeys, appendNewline: true}
 }
 
 // Encode is documented at https://golang.org/pkg/encoding/json/#Encoder.Encode
@@ -501,7 +501,7 @@ func (enc *Encoder) Encode(v interface{}) error {
 		return err
 	}
 
-	if enc.addExtraNewline {
+	if enc.appendNewline {
 		buf.data = append(buf.data, '\n')
 	}
 	b := buf.data
@@ -561,10 +561,10 @@ func (enc *Encoder) SetTrustRawMessage(on bool) {
 	}
 }
 
-// SetAddExtraNewline is an extension to the standard encoding/json package which
+// SetAppendNewline is an extension to the standard encoding/json package which
 // allows the program to toggle the addition of a newline in Encode on or off.
-func (enc *Encoder) SetAddExtraNewline(on bool) {
-	enc.addExtraNewline = on
+func (enc *Encoder) SetAppendNewline(on bool) {
+	enc.appendNewline = on
 }
 
 var encoderBufferPool = sync.Pool{

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1669,7 +1669,7 @@ func TestSetTrustRawMessage(t *testing.T) {
 	}
 }
 
-func TestSetAddExtraNewline(t *testing.T) {
+func TestSetAppendNewline(t *testing.T) {
 	buf := &bytes.Buffer{}
 	enc := NewEncoder(buf)
 
@@ -1690,9 +1690,9 @@ func TestSetAddExtraNewline(t *testing.T) {
 		)
 	}
 
-	// With SetAddExtraNewline(false), there shouldn't be a newline in the output
+	// With SetAppendNewline(false), there shouldn't be a newline in the output
 	buf.Reset()
-	enc.SetAddExtraNewline(false)
+	enc.SetAppendNewline(false)
 	if err := enc.Encode(m); err != nil {
 		t.Error(err)
 	}

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1669,6 +1669,44 @@ func TestSetTrustRawMessage(t *testing.T) {
 	}
 }
 
+func TestSetAddExtraNewline(t *testing.T) {
+	buf := &bytes.Buffer{}
+	enc := NewEncoder(buf)
+
+	m := "value"
+
+	// Default encoding adds an extra newline
+	if err := enc.Encode(m); err != nil {
+		t.Error(err)
+	}
+	b := buf.Bytes()
+	exp := []byte(`"value"`)
+	exp = append(exp, '\n')
+	if bytes.Compare(exp, b) != 0 {
+		t.Error(
+			"unexpected encoding:",
+			"expected", exp,
+			"got", b,
+		)
+	}
+
+	// With SetAddExtraNewline(false), there shouldn't be a newline in the output
+	buf.Reset()
+	enc.SetAddExtraNewline(false)
+	if err := enc.Encode(m); err != nil {
+		t.Error(err)
+	}
+	b = buf.Bytes()
+	exp = []byte(`"value"`)
+	if bytes.Compare(exp, b) != 0 {
+		t.Error(
+			"unexpected encoding:",
+			"expected", exp,
+			"got", b,
+		)
+	}
+}
+
 func TestEscapeString(t *testing.T) {
 	b := Escape(`value`)
 	x := []byte(`"value"`)


### PR DESCRIPTION
Closes #118 

This PR introduces a new `Encoder` option, toggled with `SetAddExtraNewline`.
Its default value is `true`, matching `encoding/json`'s behavior.

Setting it to false allows to use the encoder without having to handle this newline with the output.

There are for instance multiple locations in the tests where newlines are explicitly added to the expected value. Using this option would allow not to have to think about it, making the code a little bit easier to follow.