### PR TITLE
fix decoding lists of TRUE values

### DIFF
--- a/thrift/decode.go
+++ b/thrift/decode.go
@@ -324,9 +324,9 @@ func decodeFuncMapAsSetOf(t reflect.Type, seen decodeFuncCache) decodeFunc {
 
 		// See decodeFuncSliceOf for details about why this type conversion
 		// needs to be done.
-		switch l.Type {
+		switch s.Type {
 		case TRUE:
-			l.Type = BOOL
+			s.Type = BOOL
 		}
 
 		v.Set(reflect.MakeMapWithSize(t, int(s.Size)))

--- a/thrift/decode.go
+++ b/thrift/decode.go
@@ -543,11 +543,6 @@ func readList(r Reader, f func(Reader, Type) error) error {
 		return err
 	}
 
-	switch l.Type {
-	case TRUE, FALSE:
-		l.Type = BOOL
-	}
-
 	for i := 0; i < int(l.Size); i++ {
 		if err := f(r, l.Type); err != nil {
 			return with(dontExpectEOF(err), &decodeErrorList{cause: l, index: i})


### PR DESCRIPTION
This is a fix for an undocumented edge case in the thrift protocol where collections of boolean values that are all `true` are sometimes encoded with the `TRUE` type instead of `BOOL`.
