### PR TITLE
json: extendSlice optimization is still valid for go1.19

### DIFF
--- a/json/reflect.go
+++ b/json/reflect.go
@@ -1,5 +1,5 @@
-//go:build go1.18
-// +build go1.18
+//go:build go1.20
+// +build go1.20
 
 package json
 

--- a/json/reflect_optimize.go
+++ b/json/reflect_optimize.go
@@ -1,5 +1,5 @@
-//go:build !go1.18
-// +build !go1.18
+//go:build !go1.20
+// +build !go1.20
 
 package json
 


### PR DESCRIPTION
This PR enables the `extendSlice` [optimization](https://github.com/segmentio/encoding/pull/96) for go1.18 and go1.19, where it's still valid. The optimization will be disabled again in go1.20 in case internals change.

I get the following improvement for `go test ./json -run=^$ -bench=CodeUnmarshal$ -benchtime=2000x -count 10` on arm64:

```
name              old time/op    new time/op    delta
CodeUnmarshal-10     706µs ± 2%     695µs ± 2%  -1.50%  (p=0.002 n=10+10)

name              old speed      new speed      delta
CodeUnmarshal-10  2.75GB/s ± 2%  2.79GB/s ± 2%  +1.52%  (p=0.002 n=10+10)
```

The optimization was previously enabled for go1.17 in https://github.com/segmentio/encoding/pull/96.