### PR TITLE
Revert #128, update docs and add tests to Tokenizer.Remaining()

### DIFF
--- a/json/token_test.go
+++ b/json/token_test.go
@@ -45,7 +45,8 @@ func tokenize(t *testing.T, b []byte) (tokens []token) {
 	tok := NewTokenizer(b)
 
 	for tok.Next() {
-		start, end := tok.Position-len(tok.Value), tok.Position
+		end := len(b) - tok.Remaining()
+		start := end - len(tok.Value)
 		if end > len(b) {
 			t.Fatalf("token position too far [%d:%d], len(b) is %d", start, end, len(b))
 		}


### PR DESCRIPTION
This change reverts #128 because we realized that it is redundant thanks to #126 .  But rather than a straight-up revert, I updated the unit test added in #128 to add coverage to the `Remaining` func and ported over some of the docs as well.