### PR TITLE
fix encoding RawMessage that contains leading space

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test-json:
 	go test -cover -race ./json
 
 test-json-bugs:
-	go test -cover -race ./json/bugs/...
+	go test -race ./json/bugs/...
 
 test-json-1.17:
 	go test -cover -race -tags go1.17 ./json

--- a/json/bugs/issue11/main.go
+++ b/json/bugs/issue11/main.go
@@ -1,3 +1,0 @@
-package main
-
-func main() {}

--- a/json/bugs/issue136/main_test.go
+++ b/json/bugs/issue136/main_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/segmentio/encoding/json"
+)
+
+func TestIssue136(t *testing.T) {
+	input := json.RawMessage(` null`)
+
+	got, err := json.Marshal(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := bytes.TrimSpace(input)
+
+	if !bytes.Equal(got, want) {
+		t.Fatalf("Marshal(%q) = %q, want %q", input, got, want)
+	}
+}

--- a/json/bugs/issue18/main.go
+++ b/json/bugs/issue18/main.go
@@ -1,4 +1,0 @@
-package main
-
-func main() {
-}

--- a/json/bugs/issue84/main.go
+++ b/json/bugs/issue84/main.go
@@ -1,3 +1,0 @@
-package main
-
-func main() {}

--- a/json/encode.go
+++ b/json/encode.go
@@ -858,6 +858,7 @@ func (e encoder) encodeRawMessage(b []byte, p unsafe.Pointer) ([]byte, error) {
 		s = v
 	} else {
 		var err error
+		v = skipSpaces(v) // don't assume that a RawMessage starts with a token.
 		d := decoder{}
 		s, _, _, err = d.parseValue(v)
 		if err != nil {

--- a/json/parse.go
+++ b/json/parse.go
@@ -709,7 +709,6 @@ func (d decoder) parseValue(b []byte) ([]byte, []byte, Kind, error) {
 	case '{':
 		v, b, k, err = d.parseObject(b)
 	case '[':
-		k = Array
 		v, b, k, err = d.parseArray(b)
 	case '"':
 		v, b, k, err = d.parseString(b)


### PR DESCRIPTION
This library currently returns a syntax error when asked to encode
a RawMessage that happens to contain leading space byte(s).
Since some space bytes are valid JSON, these should be accepted.

This behavior also deviates from the stdlib,
which does not assume that a provided RawMessage is free of leading spaces.
