### PR TITLE
Add protobuf rewrite rule overrides

### DIFF
--- a/proto/rewrite.go
+++ b/proto/rewrite.go
@@ -139,8 +139,13 @@ func (f fieldset) index(i int) (int, int) {
 // ParseRewriteTemplate constructs a Rewriter for a protobuf type using the
 // given json template to describe the rewrite rules.
 //
-// The json template contains a representation of the message that is used as
-// the source values to overwrite in
+// The json template contains a representation of the message that is used as the
+// source values to overwrite in the protobuf targeted by the resulting rewriter.
+//
+// The rules are an optional set of RewriterRules that can provide alternative
+// Rewriters from the default used for the field type. These rules are given the
+// json.RawMessage bytes from the template, and they are expected to create a
+// Rewriter to be applied against the target protobuf.
 func ParseRewriteTemplate(typ Type, jsonTemplate []byte, rules ...RewriterRules) (Rewriter, error) {
 	switch typ.Kind() {
 	case Struct:

--- a/proto/rewrite_test.go
+++ b/proto/rewrite_test.go
@@ -297,9 +297,8 @@ func TestParseRewriteRules(t *testing.T) {
 	}
 
 	type message struct {
-		Flags       uint64       `protobuf:"varint,2,opt,name=flags,proto3"`
-		Subfield    *submessage  `protobuf:"bytes,99,opt,name=subfield,proto3"`
-		Submessages []submessage `protobuf:"bytes,100,rep,name=submessages,proto3"`
+		Flags    uint64      `protobuf:"varint,2,opt,name=flags,proto3"`
+		Subfield *submessage `protobuf:"bytes,99,opt,name=subfield,proto3"`
 	}
 
 	original := &message{


### PR DESCRIPTION
This adds an override mechanism for specifying alternative `proto.Rewriter`'s when performing template rewrites. These new rules can be provided as an optional set of parameters to `proto.ParseRewriteTemplate`, so this does not change the calling signature when rules are not used. When provided, these rules are matched against the field name in a nested fashion (see the tests for an example).

We have some cases where we need to rewrite flags that are encoded as a single integer bit mask. By combining these rules with the new `proto.BitOr` type, we can merge flags instead of replacing them:

```go
type Message struct {
	Flags uint64 `protobuf:"varint,2,opt,name=flags,proto3"`
}

typ := proto.TypeOf(reflect.TypeOf(Message{}))
template := []byte(`{"flags": 8}`) // n |= 0b1000
rw, err := proto.ParseRewriteTemplate(typ, template, proto.RewriterRules {
	"flags": proto.BitOr[uint64]{},
})
```