### PR TITLE
json: return writer errors from Encoder.Encode

### DIFF
--- a/json/json.go
+++ b/json/json.go
@@ -533,7 +533,7 @@ func (enc *Encoder) Encode(v any) error {
 		b = enc.buffer.Bytes()
 	}
 
-	if _, err := enc.writer.Write(b); err != nil {
+	if _, err = enc.writer.Write(b); err != nil {
 		enc.err = err
 	}
 

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1839,6 +1839,19 @@ func TestSetAppendNewline(t *testing.T) {
 	}
 }
 
+type errWriter struct{ err error }
+
+func (w *errWriter) Write(p []byte) (int, error) { return 0, w.err }
+
+func TestEncoderEncodeReturnsWriterError(t *testing.T) {
+	want := errors.New("boom")
+	enc := NewEncoder(&errWriter{err: want})
+
+	if err := enc.Encode("v"); !errors.Is(err, want) {
+		t.Errorf("expected writer error to surface, got %v", err)
+	}
+}
+
 func TestEscapeString(t *testing.T) {
 	b := Escape(`value`)
 	x := []byte(`"value"`)


### PR DESCRIPTION
The inner `if _, err := enc.writer.Write(b)` shadowed the outer `err` with `:=`, so the writer error got cached on `enc.err` but the function still returned the (nil) outer `err`. The first `Encode` after a write failure looked like a success; only the next call would surface the cached error via the early return at the top.

Switching to `=` so the outer `err` actually receives the writer error.

Test fails on master, passes here. Closes #139.