### PR TITLE
Fix unexportedFields Errorf format

### DIFF
--- a/json/golang_decode_test.go
+++ b/json/golang_decode_test.go
@@ -2039,7 +2039,7 @@ func TestUnmarshalUnexported(t *testing.T) {
 		t.Errorf("got error %v, expected nil", err)
 	}
 	if !reflect.DeepEqual(out, want) {
-		t.Errorf("got %q, want %q", out, want)
+		t.Errorf("got %+v, want %+v", out, want)
 	}
 }
 


### PR DESCRIPTION
Summary:
- Use a struct-compatible format in the unexported fields decode test.
- This avoids invalid `%q` usage reported by current Go vet.

Testing:
- `go test ./json`