### PR TITLE
Improve flexible ISO8601 validation throughput

### DIFF
--- a/iso8601/valid.go
+++ b/iso8601/valid.go
@@ -35,6 +35,10 @@ const (
 // Valid check value to verify whether or not it is a valid iso8601 time
 // representation.
 func Valid(value string, flags ValidFlags) bool {
+	if flags == Flexible {
+		return validFlexible(value)
+	}
+
 	var ok bool
 
 	// year
@@ -172,6 +176,105 @@ func readByte(value string, c byte) (string, bool) {
 		return value, false
 	}
 	return value[1:], true
+}
+
+func validFlexible(value string) bool {
+	n := len(value)
+	if n < 10 {
+		return false
+	}
+
+	if !isDigit(value[0]) ||
+		!isDigit(value[1]) ||
+		!isDigit(value[2]) ||
+		!isDigit(value[3]) ||
+		value[4] != '-' ||
+		!isDigit(value[5]) ||
+		!isDigit(value[6]) ||
+		value[7] != '-' ||
+		!isDigit(value[8]) ||
+		!isDigit(value[9]) {
+		return false
+	}
+
+	if n == 10 {
+		return true // date only
+	}
+
+	c := value[10]
+	if c != 'T' && c != ' ' {
+		return false
+	}
+
+	if n < 19 {
+		return false
+	}
+	if !isDigit(value[11]) ||
+		!isDigit(value[12]) ||
+		value[13] != ':' ||
+		!isDigit(value[14]) ||
+		!isDigit(value[15]) ||
+		value[16] != ':' ||
+		!isDigit(value[17]) ||
+		!isDigit(value[18]) {
+		return false
+	}
+
+	i := 19
+	if i == n {
+		return true // missing subsecond and timezone
+	}
+
+	if value[i] == '.' {
+		i++
+		j := i
+		end := i + 9
+		if end > n {
+			end = n
+		}
+		for i < end && isDigit(value[i]) {
+			i++
+		}
+		if i == j {
+			return false
+		}
+		if i == n {
+			return true // missing timezone
+		}
+	}
+
+	if value[i] == 'Z' {
+		return i+1 == n
+	}
+
+	if value[i] == ' ' {
+		i++
+		if i == n {
+			return false
+		}
+	}
+
+	if value[i] != '+' && value[i] != '-' {
+		return false
+	}
+	i++
+
+	if n-i < 4 {
+		return false
+	}
+	if !isDigit(value[i]) || !isDigit(value[i+1]) {
+		return false
+	}
+	i += 2
+
+	if i < n && value[i] == ':' {
+		i++
+	}
+
+	if n-i != 2 {
+		return false
+	}
+	return isDigit(value[i]) && isDigit(value[i+1])
 }
 
 func isDigit(c byte) bool {


### PR DESCRIPTION
This adds a fast path for `iso8601.Valid` when called with `Flexible`, which is the mode used by the existing `BenchmarkValidate` benchmark. The fast path keeps the same validation rules but walks the string by index instead of repeatedly slicing through `readDigits` / `readByte`.

I kept the existing generic flag path unchanged for non-`Flexible` combinations.

Validation:

```text
go test -count=1 ./...
```

```text
ok  	github.com/segmentio/encoding/ascii	0.178s
?   	github.com/segmentio/encoding/internal/runtime_reflect	[no test files]
ok  	github.com/segmentio/encoding/iso8601	3.175s
ok  	github.com/segmentio/encoding/json	0.780s
ok  	github.com/segmentio/encoding/json/bugs/issue11	0.537s
ok  	github.com/segmentio/encoding/json/bugs/issue136	0.876s
ok  	github.com/segmentio/encoding/json/bugs/issue18	0.648s
ok  	github.com/segmentio/encoding/json/bugs/issue84	0.763s
ok  	github.com/segmentio/encoding/proto	0.985s
ok  	github.com/segmentio/encoding/thrift	1.093s
```

I also ran a temporary differential test comparing `Valid` against the previous implementation for every flag combination over fixed edge cases and 50,000 deterministic randomized strings.

Benchmark command:

```text
go test -run '^$' -bench '^BenchmarkValidate/(success|failure)$' -benchmem -count=20 ./iso8601
```

`benchstat`:

```text
goos: darwin
goarch: arm64
pkg: github.com/segmentio/encoding/iso8601
cpu: Apple M4
                    │ baseline-bench.txt │ final-bench.txt │
                    │       sec/op       │     sec/op      vs base                │
Validate/success-10        13.960n ± 6%       6.205n ± 1%  -55.55% (p=0.000 n=20)
Validate/failure-10        11.570n ± 2%       4.454n ± 1%  -61.50% (p=0.000 n=20)
geomean                    12.71n             5.257n       -58.63%

                    │ baseline-bench.txt │ final-bench.txt │
                    │        B/op        │      B/op       vs base                 │
Validate/success-10        0.000 ± 0%         0.000 ± 0%       ~ (p=1.000 n=20)
Validate/failure-10        0.000 ± 0%         0.000 ± 0%       ~ (p=1.000 n=20)

                    │ baseline-bench.txt │ final-bench.txt │
                    │     allocs/op      │   allocs/op     vs base                 │
Validate/success-10        0.000 ± 0%         0.000 ± 0%       ~ (p=1.000 n=20)
Validate/failure-10        0.000 ± 0%         0.000 ± 0%       ~ (p=1.000 n=20)
```

I found the initial direction while experimenting with Sleepy - https://sleepy.run/mcp, then manually reduced it to this smaller `Flexible`-only patch and validated it locally.
