### PR TITLE
json: fix escapeIndex() on big-endian (s390x)

### DIFF
--- a/json/string.go
+++ b/json/string.go
@@ -1,8 +1,8 @@
 package json
 
 import (
+	"encoding/binary"
 	"math/bits"
-	"unsafe"
 )
 
 const (
@@ -16,8 +16,8 @@ const (
 // the chars <, > and & also require escaping. If no chars in `s` require
 // escaping, the return value is -1.
 func escapeIndex(s string, escapeHTML bool) int {
-	chunks := stringToUint64(s)
-	for _, n := range chunks {
+	for i := 0; i+8 <= len(s); i += 8 {
+		n := binary.LittleEndian.Uint64([]byte(s[i : i+8]))
 		// combine masks before checking for the MSB of each byte. We include
 		// `n` in the mask to check whether any of the *input* byte MSBs were
 		// set (i.e. the byte was outside the ASCII range).
@@ -26,11 +26,11 @@ func escapeIndex(s string, escapeHTML bool) int {
 			mask |= contains(n, '<') | contains(n, '>') | contains(n, '&')
 		}
 		if (mask & msb) != 0 {
-			return bits.TrailingZeros64(mask&msb) / 8
+			return bits.TrailingZeros64(mask&msb)/8 + i
 		}
 	}
 
-	for i := len(chunks) * 8; i < len(s); i++ {
+	for i := (len(s) / 8) * 8; i < len(s); i++ {
 		c := s[i]
 		if c < 0x20 || c > 0x7f || c == '"' || c == '\\' || (escapeHTML && (c == '<' || c == '>' || c == '&')) {
 			return i
@@ -78,12 +78,4 @@ func contains(n uint64, b byte) uint64 {
 // expand puts the specified byte into each of the 8 bytes of a uint64.
 func expand(b byte) uint64 {
 	return lsb * uint64(b)
-}
-
-func stringToUint64(s string) []uint64 {
-	return *(*[]uint64)(unsafe.Pointer(&sliceHeader{
-		Data: *(*unsafe.Pointer)(unsafe.Pointer(&s)),
-		Len:  len(s) / 8,
-		Cap:  len(s) / 8,
-	}))
 }

--- a/json/string_test.go
+++ b/json/string_test.go
@@ -1,6 +1,7 @@
 package json
 
 import (
+	stdjson "encoding/json"
 	"strings"
 	"testing"
 )
@@ -35,4 +36,59 @@ func benchmarkEscapeIndex(b *testing.B, s string, escapeHTML bool) {
 		escapeIndex(s, escapeHTML)
 	}
 	b.SetBytes(int64(len(s)))
+}
+
+// reference: index of the first byte that needs escaping, or -1
+func refEscapeIndex(s string, escapeHTML bool) int {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c < 0x20 || c > 0x7f || c == '"' || c == '\\' ||
+			(escapeHTML && (c == '<' || c == '>' || c == '&')) {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestEscapeIndexBigEndian(t *testing.T) {
+	inputs := []string{
+		`C:\Users\admin`,                 // backslash at byte 2
+		"key\tvalue",                     // tab at byte 3
+		"\nfoo_bar_",                     // newline at byte 0
+		`ab"cdefg`,                       // quote at byte 2
+		"line1\nline2",                   // newline at byte 5
+		`say "hello"`,                    // quote at byte 4
+		"1234567\nabc",                   // last byte of first chunk
+		"12345678\nabc",                  // first byte of second chunk
+		"-----BEGIN CERTIFICATE-----\nABCD\n-----END CERTIFICATE-----\n",
+		"<tag>&more",                       // HTML characters
+		"plain ascii with no escapes here", // no escaping needed
+		strings.Repeat("a", 33) + `"`,      // quote far into the string
+	}
+
+	for _, s := range inputs {
+		for _, html := range []bool{false, true} {
+			if got, want := escapeIndex(s, html), refEscapeIndex(s, html); got != want {
+				t.Errorf("escapeIndex(%q, %v) = %d, want %d", s, html, got, want)
+			}
+		}
+
+		b, err := Marshal(struct {
+			V string `json:"v"`
+		}{s})
+		if err != nil {
+			t.Errorf("Marshal(%q): %v", s, err)
+			continue
+		}
+		var out struct {
+			V string `json:"v"`
+		}
+		if err := stdjson.Unmarshal(b, &out); err != nil {
+			t.Errorf("%q produced invalid JSON %s: %v", s, b, err)
+			continue
+		}
+		if out.V != s {
+			t.Errorf("%q round-trips to %q", s, out.V)
+		}
+	}
 }


### PR DESCRIPTION
Fixes #170 (full story there — chasing a Portainer bug on s390x/zCX, containers with OCI labels not listing).

Putting up a PR since I already had the change sitting locally, but genuinely not sure if this is the "right" fix from a project-conventions standpoint — happy to rework it if you'd rather do it differently. I'm still fairly new to Go so go easy on me if I got a convention wrong somewhere.

## What I changed

`escapeIndex()` was casting 8-byte chunks of the string into a `uint64` via `unsafe.Pointer` (the `stringToUint64` helper), which reads native-endian. On big-endian (s390x) that's the wrong byte order for how `bits.TrailingZeros64(...)/8` figures out the byte index afterwards — it returns the mirrored position (7-k instead of k) within the chunk, so it can point at the wrong byte and skip a character that should've been escaped.

I swapped that for `binary.LittleEndian.Uint64` on each 8-byte block (same as `parse.go` already does elsewhere in this repo), and added the block offset `i` to the `TrailingZeros64(...)/8` result so the index comes out right no matter the host endianness.

Since `stringToUint64` isn't used anywhere else after that, I removed it and the now-unused `unsafe` import from `json/string.go`. Left `sliceHeader` alone since it's still used in `json/codec.go`.

## Testing

Added `TestEscapeIndexBigEndian` to `json/string_test.go`:

- runs `escapeIndex` against a plain byte-by-byte reference scanner for a handful of strings with the special character at different positions (including right around the 8-byte chunk boundary, since that's where things went wrong for me)
- also round-trips each string through this package's `Marshal` and stdlib `encoding/json`'s `Unmarshal` to check the actual JSON output is valid and comes back as the same string, similar to the reproducer in #170

On amd64:
- `go build ./...` — fine
- `go vet ./json` — some pre-existing warnings in other test files, unrelated to this change, didn't touch those
- `go test ./json -run TestEscapeIndexBigEndian` — passes

I don't have a Go toolchain on the s390x box itself (zCX/Tumbleweed, not really meant for dev work), so I built and ran the test on a big-endian setup I have access to elsewhere — it failed against the old code and passes with this change.

Only touched `json/string.go` and `json/string_test.go`, didn't touch `go.mod`/`go.sum`.
