### PR TITLE
json: decode valid string literals into Number

### DIFF
--- a/json/decode.go
+++ b/json/decode.go
@@ -267,9 +267,21 @@ func (d decoder) decodeNumber(b []byte, p unsafe.Pointer) ([]byte, error) {
 		return b[4:], nil
 	}
 
-	v, r, _, err := d.parseNumber(b)
-	if err != nil {
-		return d.inputError(b, numberType)
+	var v, r []byte
+	var err error
+	if len(b) > 0 && b[0] == '"' {
+		v, r, _, err = d.parseStringUnquote(b, nil)
+		if err != nil {
+			return r, err
+		}
+		if _, rest, _, err := d.parseNumber(v); err != nil || len(rest) != 0 {
+			return r, fmt.Errorf("json: invalid number literal %q", v)
+		}
+	} else {
+		v, r, _, err = d.parseNumber(b)
+		if err != nil {
+			return d.inputError(b, numberType)
+		}
 	}
 
 	if (d.flags & DontCopyNumber) != 0 {

--- a/json/number_string_test.go
+++ b/json/number_string_test.go
@@ -1,0 +1,58 @@
+package json
+
+import (
+	stdjson "encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestUnmarshalNumberString(t *testing.T) {
+	for _, input := range []string{
+		`151`, `null`, `"151"`, `"-0"`, `"1.25"`, `"1e+1000"`, `"\u0031\u0035\u0031"`,
+		`""`, `"01"`, `"+1"`, `"1."`, `"1e"`, `"1 2"`, `"1 "`, `" 1"`, `"null"`, `"NaN"`,
+	} {
+		t.Run(input, func(t *testing.T) {
+			for _, flags := range []ParseFlags{0, DontCopyNumber, ZeroCopy} {
+				want, got := Number("7"), Number("7")
+				wantErr := stdjson.Unmarshal([]byte(input), &want)
+				_, gotErr := Parse([]byte(input), &got, flags)
+				if (wantErr == nil) != (gotErr == nil) {
+					t.Fatalf("flags=%v: error=%v, standard library error=%v", flags, gotErr, wantErr)
+				}
+				if gotErr == nil && got != want {
+					t.Fatalf("flags=%v: got %q, want %q", flags, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestUnmarshalNumberStringContainers(t *testing.T) {
+	for _, test := range []struct {
+		input string
+		typ   reflect.Type
+	}{
+		{`{"id":"151","next":2}`, reflect.TypeOf(struct {
+			ID   Number `json:"id"`
+			Next int    `json:"next"`
+		}{})},
+		{`["151",2,null,"1.5"]`, reflect.TypeOf([]Number{})},
+		{`{"id":"151"}`, reflect.TypeOf(map[string]Number{})},
+		{`{"id":"151"}`, reflect.TypeOf(struct {
+			ID Number `json:"id,string"`
+		}{})},
+	} {
+		t.Run(test.input+test.typ.String(), func(t *testing.T) {
+			want, got := reflect.New(test.typ).Interface(), reflect.New(test.typ).Interface()
+			if err := stdjson.Unmarshal([]byte(test.input), want); err != nil {
+				t.Fatal(err)
+			}
+			if err := Unmarshal([]byte(test.input), got); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("got %#v, want %#v", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #143.

The standard library accepts a JSON string containing a valid number when decoding into `json.Number`. This package currently sends the opening quote directly to `parseNumber`, so inputs such as `{"id":"151"}` fail.

Unquote string input using the existing string parser, then validate the entire unquoted value as a number. Requiring an empty remainder prevents accepting prefixes such as `"1 2"`, `"01"`, or `"1 "`. The unquoted-number and null paths retain their existing behavior, as do the `DontCopyNumber`/`ZeroCopy` options.

Tests compare results and acceptance with `encoding/json`, covering integer, decimal, exponent, escaped digits, invalid literals, null preservation, structs, slices, maps, and the existing `,string` field tag.

## Validation

- New regressions fail on the original code for valid string numbers and nested fields.
- `go test -race ./json ./json/bugs/... -count=1` passes.
- `make test` passes: ASCII, JSON and its issue regressions, protobuf, ISO8601, Thrift, and all root-module packages with `-tags purego`; these targets include the race detector. The separate benchmarks module was not built.
- `git diff --check` passes.
- `go vet ./json/...` reports existing findings in copied standard-library tests (`golang_decode_test.go:2027`, `golang_tagkey_test.go:60`) and the unchanged `unsafe.Pointer` conversion in `codec.go:850`.

## AI assistance

Codex implemented this patch and ran the local checks at my request. This contribution is based on reproducing the reported compatibility issue, not production usage.
